### PR TITLE
feat(logical_amr): add simple order management

### DIFF
--- a/daisi/src/cpps/logical/amr/CMakeLists.txt
+++ b/daisi/src/cpps/logical/amr/CMakeLists.txt
@@ -13,3 +13,7 @@ target_link_libraries(daisi_cpps_logical_amr_amr_logical_agent
     daisi_cpps_logical_order_management_stn_order_management
     daisi_utils
 )
+
+target_include_directories(daisi_cpps_amr_amr_description INTERFACE
+    ${DAISI_SOURCE_DIR}/src
+)

--- a/daisi/src/cpps/logical/order_management/CMakeLists.txt
+++ b/daisi/src/cpps/logical/order_management/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(daisi_cpps_logical_order_management_order_management
 target_link_libraries(daisi_cpps_logical_order_management_order_management
     INTERFACE
     daisi_material_flow_model_task
+    daisi_cpps_amr_amr_description
 )
 
 add_library(daisi_cpps_logical_order_management_metrics_composition INTERFACE)
@@ -44,4 +45,21 @@ target_link_libraries(daisi_cpps_logical_order_management_stn_order_management
     daisi_cpps_logical_order_management_auction_based_order_management
     daisi_datastructure_simple_temporal_network
     daisi_cpps_amr_amr_mobility_helper
+)
+add_library(daisi_cpps_logical_order_management_simple_order_management STATIC)
+target_sources(daisi_cpps_logical_order_management_simple_order_management
+    PUBLIC
+    simple_order_management.h
+    simple_order_management.cpp
+)
+target_link_libraries(daisi_cpps_logical_order_management_simple_order_management
+    PUBLIC
+    daisi_cpps_logical_order_management_order_management
+    daisi_cpps_amr_amr_mobility_helper
+    ns3::libcore
+    solanet_serialize
+)
+target_include_directories(daisi_cpps_logical_order_management_simple_order_management
+    PUBLIC
+    ${DAISI_SOURCE_DIR}/src
 )

--- a/daisi/src/cpps/logical/order_management/CMakeLists.txt
+++ b/daisi/src/cpps/logical/order_management/CMakeLists.txt
@@ -1,3 +1,13 @@
+add_library(daisi_cpps_logical_order_management_order_management_helper STATIC)
+target_sources(daisi_cpps_logical_order_management_order_management_helper
+PUBLIC
+order_management_helper.h
+order_management_helper.cpp
+)
+target_link_libraries(daisi_cpps_logical_order_management_order_management_helper
+daisi_material_flow_model_task
+)
+
 add_library(daisi_cpps_logical_order_management_order_management INTERFACE)
 target_sources(daisi_cpps_logical_order_management_order_management
     INTERFACE
@@ -7,7 +17,9 @@ target_link_libraries(daisi_cpps_logical_order_management_order_management
     INTERFACE
     daisi_material_flow_model_task
     daisi_cpps_amr_amr_description
+    daisi_cpps_logical_order_management_order_management_helper
 )
+
 
 add_library(daisi_cpps_logical_order_management_metrics_composition INTERFACE)
 target_sources(daisi_cpps_logical_order_management_metrics_composition

--- a/daisi/src/cpps/logical/order_management/order_management.h
+++ b/daisi/src/cpps/logical/order_management/order_management.h
@@ -25,6 +25,7 @@
 #include "cpps/amr/amr_description.h"
 #include "cpps/amr/amr_topology.h"
 #include "material_flow/model/task.h"
+#include "metrics_composition.h"
 #include "utils/structure_helpers.h"
 
 namespace daisi::cpps::logical {
@@ -37,11 +38,20 @@ public:
 
   virtual ~OrderManagement() = default;
 
+  /// @brief check wether the order management has a current task assigned
   virtual bool hasTasks() const = 0;
+
+  /// @brief get the current task
   virtual daisi::material_flow::Task getCurrentTask() const = 0;
+
+  /// @brief replace the current task with the first task stored in the management's queue
   virtual bool setNextTask() = 0;
 
+  /// @brief check wether a new task can be added to the management's queue
   virtual bool canAddTask(const daisi::material_flow::Task &task) = 0;
+
+  /// @brief insert a task into the management's queue.
+  /// @return true if the insertion was successful, false otherwise
   virtual bool addTask(const daisi::material_flow::Task &task) = 0;
 
 protected:

--- a/daisi/src/cpps/logical/order_management/order_management.h
+++ b/daisi/src/cpps/logical/order_management/order_management.h
@@ -26,6 +26,7 @@
 #include "cpps/amr/amr_topology.h"
 #include "material_flow/model/task.h"
 #include "metrics_composition.h"
+#include "order_management_helper.h"
 #include "utils/structure_helpers.h"
 
 namespace daisi::cpps::logical {

--- a/daisi/src/cpps/logical/order_management/order_management_helper.cpp
+++ b/daisi/src/cpps/logical/order_management/order_management_helper.cpp
@@ -1,0 +1,40 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "order_management_helper.h"
+
+using namespace daisi::material_flow;
+namespace daisi::cpps::logical {
+
+template <class> inline constexpr bool always_false_v = false;
+
+std::optional<Location> OrderManagementHelper::getEndLocationOfOrder(const Order &order) {
+  return std::visit(
+      [&](auto &&arg) -> std::optional<Location> {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, MoveOrder>) {
+          return std::get<MoveOrder>(order).getMoveOrderStep().getLocation();
+        } else if constexpr (std::is_same_v<T, TransportOrder>) {
+          return std::get<TransportOrder>(order).getDeliveryTransportOrderStep().getLocation();
+        } else if constexpr (std::is_same_v<T, ActionOrder>) {
+          return std::nullopt;
+        } else {
+          static_assert(always_false_v<T>, "Order type not handled");
+        }
+      },
+      order);
+}
+}  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/order_management/order_management_helper.h
+++ b/daisi/src/cpps/logical/order_management/order_management_helper.h
@@ -1,0 +1,29 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "material_flow/model/task.h"
+
+namespace daisi::cpps::logical {
+
+class OrderManagementHelper {
+public:
+  /// @brief get the end location of a given order.
+  /// @param order the order to get the end location for
+  /// @return the end location or null, if the passed order is an ActionOrder
+  static std::optional<daisi::material_flow::Location> getEndLocationOfOrder(
+      const daisi::material_flow::Order &order);
+};
+}  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/order_management/simple_order_management.cpp
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.cpp
@@ -1,0 +1,199 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "simple_order_management.h"
+
+using namespace daisi::material_flow;
+namespace daisi::cpps::logical {
+
+template <class> inline constexpr bool always_false_v = false;
+
+SimpleOrderManagement::SimpleOrderManagement(const AmrDescription &amr_description,
+                                             const Topology &topology,
+                                             const daisi::util::Pose &pose)
+    : OrderManagement(amr_description, topology, pose),
+      current_task_(),
+      current_ordering_(),
+      current_metrics_(),
+      current_end_position_(pose.position),
+      time_now_(0) {}
+
+Metrics SimpleOrderManagement::getCurrentMetrics() const { return current_metrics_; }
+
+void SimpleOrderManagement::setCurrentTime(const daisi::util::Duration &now) {
+  if (now < time_now_) {
+    throw std::invalid_argument("new time must be later than current time");
+  }
+  time_now_ = now;
+}
+
+bool SimpleOrderManagement::hasTasks() const { return current_task_.has_value(); }
+
+Task SimpleOrderManagement::getCurrentTask() const {
+  if (!hasTasks()) {
+    throw std::logic_error("no tasks available");
+  }
+  return current_task_.value();
+}
+
+bool SimpleOrderManagement::setNextTask() {
+  if (!current_ordering_.empty()) {
+    current_task_ = current_ordering_.front();
+    current_ordering_.erase(current_ordering_.begin());
+    return true;
+  }
+  current_task_ = std::nullopt;
+  return false;
+}
+
+bool SimpleOrderManagement::canAddTask(const Task &task) {
+  SimpleOrderManagement copy(*this);
+  bool result = copy.addTask(task);
+
+  return result;
+}
+
+bool SimpleOrderManagement::addTask(const Task &task) {
+  // simply add all orders in the given order
+  const auto orders = task.getOrders();
+  if (orders.empty()) {
+    throw std::invalid_argument("Task must have at least one order");
+  }
+
+  current_ordering_.push_back(task);
+
+  // update current_metrics to match the final order of the new task
+  updateCurrentMetrics();
+
+  // find final order with an endpoint to update current_end_position_
+  std::optional<Order> final_order = std::nullopt;
+  for (auto rev_orders_it = orders.rbegin(); rev_orders_it != orders.rend(); rev_orders_it++) {
+    if (std::holds_alternative<TransportOrder>(*rev_orders_it) ||
+        std::holds_alternative<MoveOrder>(*rev_orders_it)) {
+      final_order = *rev_orders_it;
+      break;
+    }
+  }
+  if (!final_order.has_value()) {
+    throw std::logic_error("Task must contain at least one TransportOrder or MoveOrder");
+  }
+  if (std::holds_alternative<TransportOrder>(final_order.value())) {
+    TransportOrder transport_order = std::get<TransportOrder>(final_order.value());
+    current_end_position_ =
+        transport_order.getDeliveryTransportOrderStep().getLocation().getPosition();
+  } else {
+    MoveOrder move_order = std::get<MoveOrder>(final_order.value());
+    current_end_position_ = move_order.getMoveOrderStep().getLocation().getPosition();
+  }
+
+  return true;
+}
+
+void SimpleOrderManagement::updateCurrentMetrics() {
+  // calculate the start time and metrics for the new task
+  auto start_time = std::max(current_metrics_.getMakespan(), time_now_);
+
+  Metrics new_current_metrics;
+  Task new_task = current_ordering_.back();
+  auto orders = new_task.getOrders();
+
+  // iterate through orders to find the correct start time for the final order
+  for (auto it = orders.begin(); it != orders.end(); it++) {
+    new_current_metrics = Metrics();
+    auto order = *it;
+    insertOrderPropertiesIntoMetrics(order, new_current_metrics, new_task, start_time);
+    start_time = new_current_metrics.getMakespan();
+  }
+
+  // update current metrics
+  current_metrics_ = new_current_metrics;
+}
+
+void SimpleOrderManagement::insertOrderPropertiesIntoMetrics(
+    const Order &order, Metrics &metrics, const Task &task,
+    const daisi::util::Duration &start_time) {
+  if (!metrics.isStartTimeSet()) {
+    metrics.setStartTime(start_time);
+  }
+  const auto orders = task.getOrders();
+  auto order_it = std::find(orders.rbegin(), orders.rend(), order);
+  const int order_index = orders.rend() - order_it - 1;
+
+  // determine end location of previous order
+  std::optional<Location> previous_location;
+  order_it++;
+  for (; order_it != orders.rend(); order_it++) {
+    previous_location = getEndLocationOfOrder(*order_it);
+    if (previous_location.has_value()) {
+      break;
+    }
+  }
+  daisi::util::Position previous_position;
+  if (!previous_location.has_value()) {
+    if (!current_end_position_.has_value()) {
+      // previous_position = current_pose_.position_;
+      throw std::logic_error("there must exist a location for the amr to start from");
+    }
+    // else {
+    previous_position = current_end_position_.value();
+    // }
+  } else {
+    previous_position = previous_location.value().getPosition();
+  }
+  auto funcs = materialFlowToFunctionalities({order}, previous_position);
+
+  if (std::holds_alternative<MoveOrder>(order)) {
+    if (order_index == 0) {
+      throw std::invalid_argument("move order should not be first");
+    }
+    metrics.empty_travel_time += AmrMobilityHelper::estimateDuration(
+        daisi::util::Pose{}, funcs, amr_description_, topology_, false);
+
+    metrics.empty_travel_distance = AmrMobilityHelper::calculateDistance(previous_position, funcs);
+  } else if (std::holds_alternative<TransportOrder>(order)) {
+    auto res = AmrMobilityHelper::calculateMetricsByDomain(previous_position, funcs,
+                                                           amr_description_, topology_);
+    metrics.empty_travel_time += std::get<0>(res);
+    metrics.loaded_travel_time += std::get<1>(res);
+    metrics.action_time += std::get<2>(res);
+    metrics.empty_travel_distance += std::get<3>(res);
+    metrics.loaded_travel_distance += std::get<4>(res);
+  } else if (std::holds_alternative<ActionOrder>(order)) {
+    metrics.action_time += AmrMobilityHelper::estimateDuration(daisi::util::Pose{}, funcs,
+                                                               amr_description_, topology_, false);
+  } else {
+    throw std::invalid_argument("Order type not supported");
+  }
+}
+
+std::optional<Location> SimpleOrderManagement::getEndLocationOfOrder(const Order &order) {
+  return std::visit(
+      [&](auto &&arg) -> std::optional<Location> {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, MoveOrder>) {
+          return std::get<MoveOrder>(order).getMoveOrderStep().getLocation();
+        } else if constexpr (std::is_same_v<T, TransportOrder>) {
+          return std::get<TransportOrder>(order).getDeliveryTransportOrderStep().getLocation();
+        } else if constexpr (std::is_same_v<T, ActionOrder>) {
+          return std::nullopt;
+        } else {
+          static_assert(always_false_v<T>, "Order type not handled");
+        }
+      },
+      order);
+}
+
+}  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/order_management/simple_order_management.cpp
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.cpp
@@ -90,14 +90,8 @@ bool SimpleOrderManagement::addTask(const Task &task) {
   if (!final_order.has_value()) {
     throw std::logic_error("Task must contain at least one TransportOrder or MoveOrder");
   }
-  if (std::holds_alternative<TransportOrder>(final_order.value())) {
-    TransportOrder transport_order = std::get<TransportOrder>(final_order.value());
-    expected_end_position_ =
-        transport_order.getDeliveryTransportOrderStep().getLocation().getPosition();
-  } else {
-    MoveOrder move_order = std::get<MoveOrder>(final_order.value());
-    expected_end_position_ = move_order.getMoveOrderStep().getLocation().getPosition();
-  }
+  auto end_location = getEndLocationOfOrder(final_order.value());
+  expected_end_position_ = end_location->getPosition();
 
   return true;
 }

--- a/daisi/src/cpps/logical/order_management/simple_order_management.h
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.h
@@ -13,6 +13,10 @@
 // <https://www.gnu.org/licenses/>.
 //
 // SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_ORDER_MANAGEMENT_SIMPLE_ORDER_MANAGEMENT_H_
+#define DAISI_CPPS_LOGICAL_ORDER_MANAGEMENT_SIMPLE_ORDER_MANAGEMENT_H_
+
 #include "cpps/amr/amr_mobility_helper.h"
 #include "cpps/amr/physical/material_flow_functionality_mapping.h"
 #include "order_management.h"
@@ -82,3 +86,5 @@ private:
 };
 
 }  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/order_management/simple_order_management.h
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.h
@@ -49,13 +49,6 @@ public:
 
   void setCurrentTime(const daisi::util::Duration &now);
 
-  // TODO: think about moving the method to avoid duplicates
-  /// @brief get the end location of a given order.
-  /// @param order the order to get the end location for
-  /// @return the end location or null, if the passed order is an ActionOrder
-  std::optional<daisi::material_flow::Location> getEndLocationOfOrder(
-      const daisi::material_flow::Order &order);
-
 private:
   /// @brief update the current metrics by assuming that a new task has been inserted into the
   /// management's queue.

--- a/daisi/src/cpps/logical/order_management/simple_order_management.h
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.h
@@ -1,0 +1,86 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+#include "cpps/amr/amr_mobility_helper.h"
+#include "cpps/amr/physical/material_flow_functionality_mapping.h"
+#include "order_management.h"
+
+namespace daisi::cpps::logical {
+class SimpleOrderManagement : public OrderManagement {
+public:
+  SimpleOrderManagement(const AmrDescription &amr_description, const Topology &topology,
+                        const daisi::util::Pose &pose);
+
+  ~SimpleOrderManagement() = default;
+
+  /// @brief return the metrics of the final order contained in the last task that has been added to
+  /// the management
+  Metrics getCurrentMetrics() const;
+
+  /// @brief check wether the order management has a current task assigned
+  bool hasTasks() const override;
+
+  /// @brief get the current task
+  daisi::material_flow::Task getCurrentTask() const override;
+
+  /// @brief replace the current task with the first task stored in the management's queue
+  /// @return true if the new assignment of current task was successful, false if there were no more
+  /// tasks in the management's queue
+  bool setNextTask() override;
+
+  /// @brief check wether a new task can be added to the management's queue
+  bool canAddTask(const daisi::material_flow::Task &task) override;
+
+  /// @brief insert a task into the management's queue. Update the current metrics and end location.
+  /// @return true if the insertion was successful, false otherwise
+  bool addTask(const daisi::material_flow::Task &task) override;
+
+  void setCurrentTime(const daisi::util::Duration &now);
+
+  // TODO: think about moving the method to avoid duplicates
+  /// @brief get the end location of a given order.
+  /// @param order the order to get the end location for
+  /// @return the end location or null, if the passed order is an ActionOrder
+  std::optional<daisi::material_flow::Location> getEndLocationOfOrder(
+      const daisi::material_flow::Order &order);
+
+private:
+  /// @brief update the current metrics by assuming that a new task has been inserted into the
+  /// management's queue.
+  /// Uses the metrics from the last order of the previous task.
+  void updateCurrentMetrics();
+
+  /// @brief calculate the metrics for the given order of the given task and insert them into the
+  /// given metrics.
+  /// @param order the order the metrics should be calculated for
+  /// @param metrics the container to insert the metrics
+  /// @param task the task for the passed order
+  /// @param start_time the start time of the order
+  void insertOrderPropertiesIntoMetrics(const daisi::material_flow::Order &order, Metrics &metrics,
+                                        const daisi::material_flow::Task &task,
+                                        const daisi::util::Duration &start_time);
+
+  /// @brief the currently active task
+  std::optional<daisi::material_flow::Task> current_task_;
+  /// @brief the management's queued tasks (without the current task)
+  std::vector<daisi::material_flow::Task> current_ordering_;
+  /// @brief the metrics of the final order that has been added
+  Metrics current_metrics_;
+  /// @brief the final position after executing all currently known orders
+  std::optional<daisi::util::Position> current_end_position_;
+  daisi::util::Duration time_now_;
+};
+
+}  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/order_management/simple_order_management.h
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.h
@@ -27,7 +27,7 @@ public:
 
   /// @brief return the metrics of the final order contained in the last task that has been added to
   /// the management
-  Metrics getCurrentMetrics() const;
+  Metrics getFinalMetrics() const;
 
   /// @brief check wether the order management has a current task assigned
   bool hasTasks() const override;
@@ -60,7 +60,7 @@ private:
   /// @brief update the current metrics by assuming that a new task has been inserted into the
   /// management's queue.
   /// Uses the metrics from the last order of the previous task.
-  void updateCurrentMetrics();
+  void updateFinalMetrics();
 
   /// @brief calculate the metrics for the given order of the given task and insert them into the
   /// given metrics.
@@ -73,13 +73,18 @@ private:
                                         const daisi::util::Duration &start_time);
 
   /// @brief the currently active task
-  std::optional<daisi::material_flow::Task> current_task_;
+  std::optional<daisi::material_flow::Task> active_task_;
+
   /// @brief the management's queued tasks (without the current task)
-  std::vector<daisi::material_flow::Task> current_ordering_;
+  std::vector<daisi::material_flow::Task> queue_;
+
   /// @brief the metrics of the final order that has been added
-  Metrics current_metrics_;
+  Metrics final_metrics_;
+
   /// @brief the final position after executing all currently known orders
-  std::optional<daisi::util::Position> current_end_position_;
+  std::optional<daisi::util::Position> expected_end_position_;
+
+  /// @brief the current time
   daisi::util::Duration time_now_;
 };
 

--- a/daisi/src/cpps/logical/order_management/stn_order_management.cpp
+++ b/daisi/src/cpps/logical/order_management/stn_order_management.cpp
@@ -166,7 +166,7 @@ bool StnOrderManagement::addTask(
 
     addDurationConstraints(start_curr, finish_curr, *orders_it, info);
 
-    auto end_location_of_order = getEndLocationOfOrder(*orders_it);
+    auto end_location_of_order = OrderManagementHelper::getEndLocationOfOrder(*orders_it);
     if (end_location_of_order.has_value()) {
       info.end_locations.push_back(end_location_of_order.value());
     } else {
@@ -397,23 +397,6 @@ void StnOrderManagement::addOrderingConstraintBetweenTasks(
 
     updateDurationConstraints(insertion_point.new_index + 1);
   }
-}
-
-std::optional<Location> StnOrderManagement::getEndLocationOfOrder(const Order &order) {
-  return std::visit(
-      [&](auto &&arg) -> std::optional<Location> {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, MoveOrder>) {
-          return std::get<MoveOrder>(order).getMoveOrderStep().getLocation();
-        } else if constexpr (std::is_same_v<T, TransportOrder>) {
-          return std::get<TransportOrder>(order).getDeliveryTransportOrderStep().getLocation();
-        } else if constexpr (std::is_same_v<T, ActionOrder>) {
-          return std::nullopt;
-        } else {
-          static_assert(kAlwaysFalseV<T>, "Order type not handled");
-        }
-      },
-      order);
 }
 
 daisi::util::Duration StnOrderManagement::calcOrderDurationForInsert(

--- a/daisi/src/cpps/logical/order_management/stn_order_management.h
+++ b/daisi/src/cpps/logical/order_management/stn_order_management.h
@@ -147,13 +147,6 @@ protected:
                                         const int &task_ordering_index,
                                         const daisi::util::Duration &start_time);
 
-  // TODO: think about moving the method to avoid duplicates
-  /// @brief get the end location of a given order.
-  /// @param order the order to get the end location for
-  /// @return the end location or null, if the passed order is an ActionOrder
-  static std::optional<daisi::material_flow::Location> getEndLocationOfOrder(
-      const daisi::material_flow::Order &order);
-
   // simple helper
   VertexIterator getVertexIteratorOfOrder(const daisi::material_flow::Order &order, bool start);
   int getVertexIndexOfOrder(const daisi::material_flow::Order &order, bool start);

--- a/daisi/src/cpps/logical/order_management/stn_order_management.h
+++ b/daisi/src/cpps/logical/order_management/stn_order_management.h
@@ -43,21 +43,40 @@ public:
 
   ~StnOrderManagement() = default;
 
+  /// @brief check wether the order management has a current task assigned
   bool hasTasks() const override;
+
+  /// @brief get the current task
   daisi::material_flow::Task getCurrentTask() const override;
+
+  /// @brief set the current task to the first task that is currently queued
+  /// @return true if the assignment was successful
   bool setNextTask() override;
 
+  /// @brief check wether a new task can be assigned to the management
+  /// @param task the task to be assigned
+  /// @return true if the assignment can be made
   bool canAddTask(const daisi::material_flow::Task &task) override;
+
+  /// @brief assign a new task to the management
+  /// @param task the task to be assigned
+  /// @param insertion_point the position in the managements queue where the task should be inserted
+  /// @return true if the insertion was successful
   bool addTask(const daisi::material_flow::Task &task,
                std::shared_ptr<InsertionPoint> insertion_point = nullptr) override;
-
+  /// @brief get infos about the latest task insertion (also includes the check wether a task can be
+  /// inserted)
+  /// @return the MetricsComposition and InsertionPoint of the latest task insertion
   std::pair<MetricsComposition, std::shared_ptr<InsertionPoint>> getLatestCalculatedInsertionInfo()
       const override;
 
+  /// @brief set the management's current time
+  /// @param now
   void setCurrentTime(const daisi::util::Duration &now);
 
   using VertexIterator = std::vector<StnOrderManagementVertex>::iterator;
 
+  /// @brief contains a task and the end locations and metrics compositions for the single orders
   struct TaskInsertInfo {
     daisi::material_flow::Task task;
 
@@ -108,18 +127,30 @@ protected:
 
   std::vector<StnInsertionPoint> calcInsertionPoints();
 
+  /// @brief update the metrics compositions of all currently queued tasks as well as the total
+  /// metrics. sort the current ordering by start time. method is called after inserting a new task.
   void updateCurrentOrdering();
 
   daisi::util::Position getLastPositionBefore(int task_index);
 
   daisi::util::Duration calcOrderDurationForInsert(const daisi::material_flow::Order &order,
                                                    const TaskInsertInfo &task_insert_info) const;
-
+  /// @brief calculate the metrics for the given order of the given task and insert them into the
+  /// given metrics.
+  /// @param order the order the metrics should be calculated for
+  /// @param metrics the container to insert the metrics
+  /// @param task_insert_info the TaskInsertInfo for the passed order
+  /// @param task_ordering_index the current ordering index for the task
+  /// @param start_time the start time of the order
   void insertOrderPropertiesIntoMetrics(const daisi::material_flow::Order &order, Metrics &metrics,
                                         const TaskInsertInfo &task_insert_info,
                                         const int &task_ordering_index,
                                         const daisi::util::Duration &start_time);
 
+  // TODO: think about moving the method to avoid duplicates
+  /// @brief get the end location of a given order.
+  /// @param order the order to get the end location for
+  /// @return the end location or null, if the passed order is an ActionOrder
   static std::optional<daisi::material_flow::Location> getEndLocationOfOrder(
       const daisi::material_flow::Order &order);
 

--- a/daisi/tests/unittests/CMakeLists.txt
+++ b/daisi/tests/unittests/CMakeLists.txt
@@ -61,3 +61,16 @@ target_link_libraries(DaisiCppsOrderManagementStnOrderManagement
         daisi_cpps_logical_order_management_stn_order_management
         daisi_cpps_amr_physical_material_flow_functionality_mapping
 )
+
+add_executable(DaisiCppsOrderManagementSimpleOrderManagement "")
+target_sources(DaisiCppsOrderManagementSimpleOrderManagement
+        PRIVATE
+        cpps/order_management/simple_order_management_test.cpp
+)
+target_link_libraries(DaisiCppsOrderManagementSimpleOrderManagement
+        PRIVATE
+        Catch2::Catch2WithMain
+        ns3::libcore
+        daisi_cpps_logical_order_management_simple_order_management
+        daisi_cpps_amr_physical_material_flow_functionality_mapping
+)

--- a/daisi/tests/unittests/cpps/order_management/simple_order_management_test.cpp
+++ b/daisi/tests/unittests/cpps/order_management/simple_order_management_test.cpp
@@ -84,7 +84,7 @@ TEST_CASE("SimpleOrderManagement One Simple Transport Order", "[adding and remov
   // act
   auto opt_result = management.canAddTask(simple_task);
   REQUIRE(opt_result);
-  auto metrics = management.getCurrentMetrics();
+  auto metrics = management.getFinalMetrics();
   REQUIRE(metrics.getTime() == 0);
   REQUIRE(metrics.loaded_travel_time == 0);
   REQUIRE(metrics.empty_travel_time == 0);
@@ -102,7 +102,7 @@ TEST_CASE("SimpleOrderManagement One Simple Transport Order", "[adding and remov
   // act
   auto add_results = management.addTask(simple_task);
   REQUIRE(add_results);
-  metrics = management.getCurrentMetrics();
+  metrics = management.getFinalMetrics();
   // assert metrics results
   REQUIRE(metrics.loaded_travel_time == 11);
   REQUIRE(metrics.empty_travel_time == 11);
@@ -146,7 +146,7 @@ TEST_CASE("SimpleOrderManagement Two Simple Transport Orders", "[adding and remo
 
   auto can_add_2 = management.canAddTask(simple_task_2);
   REQUIRE(can_add_2);
-  auto metrics = management.getCurrentMetrics();
+  auto metrics = management.getFinalMetrics();
   REQUIRE(metrics.getTime() == 0);
   REQUIRE(metrics.loaded_travel_time == 0);
   REQUIRE(metrics.empty_travel_time == 0);
@@ -161,7 +161,7 @@ TEST_CASE("SimpleOrderManagement Two Simple Transport Orders", "[adding and remo
   auto add_1_result = management.addTask(simple_task_1);
   REQUIRE(add_1_result);
 
-  auto add_1_metrics = management.getCurrentMetrics();
+  auto add_1_metrics = management.getFinalMetrics();
 
   // can add task 2 after 1
   auto can_add_2_2 = management.canAddTask(simple_task_2);
@@ -171,7 +171,7 @@ TEST_CASE("SimpleOrderManagement Two Simple Transport Orders", "[adding and remo
   auto add_2_result = management.addTask(simple_task_2);
   REQUIRE(add_2_result);
 
-  auto add_2_metrics = management.getCurrentMetrics();
+  auto add_2_metrics = management.getFinalMetrics();
   REQUIRE(add_2_metrics.loaded_travel_time == 6);
   REQUIRE(add_2_metrics.empty_travel_time == 6);
   REQUIRE(add_2_metrics.action_time == 15);
@@ -219,7 +219,7 @@ TEST_CASE("SimpleOrderManagement Two Simple Transport Orders multiple times",
   REQUIRE(!management.hasTasks());
   auto add_2_1_result = management.addTask(simple_task_2);
   REQUIRE(add_2_1_result);
-  auto add_2_1_metrics = management.getCurrentMetrics();
+  auto add_2_1_metrics = management.getFinalMetrics();
   REQUIRE(management.setNextTask());
   auto second_task = management.getCurrentTask();
   REQUIRE(second_task.getName() == "simple_task_2");
@@ -231,7 +231,7 @@ TEST_CASE("SimpleOrderManagement Two Simple Transport Orders multiple times",
   auto add_1_result = management.addTask(simple_task_1);
   REQUIRE(add_1_result);
 
-  auto add_1_metrics = management.getCurrentMetrics();
+  auto add_1_metrics = management.getFinalMetrics();
   auto makespan_task_1 = add_1_metrics.getMakespan();
 
   // makespan of task 1 must depend on the makespan of task 2
@@ -245,7 +245,7 @@ TEST_CASE("SimpleOrderManagement Two Simple Transport Orders multiple times",
   auto add_2_2_result = management.addTask(simple_task_2);
   REQUIRE(add_2_2_result);
 
-  auto add_2_2_metrics = management.getCurrentMetrics();
+  auto add_2_2_metrics = management.getFinalMetrics();
   REQUIRE(add_2_2_metrics.loaded_travel_time == 6);
   REQUIRE(add_2_2_metrics.empty_travel_time == 6);
   REQUIRE(add_2_2_metrics.action_time == 15);
@@ -303,9 +303,9 @@ TEST_CASE("SimpleOrderManagement Three Simple Transport Orders", "[adding and re
   Task simple_task_3("simple_task_3", {simple_to_3}, {});
 
   auto add_1_opt = management.addTask(simple_task_1);
-  auto add_1_metrics = management.getCurrentMetrics();
+  auto add_1_metrics = management.getFinalMetrics();
   auto add_2_opt = management.addTask(simple_task_2);
-  auto add_2_metrics = management.getCurrentMetrics();
+  auto add_2_metrics = management.getFinalMetrics();
 
   REQUIRE(add_1_opt);
   REQUIRE(add_2_opt);
@@ -318,7 +318,7 @@ TEST_CASE("SimpleOrderManagement Three Simple Transport Orders", "[adding and re
   auto can_add_3_opt = management.canAddTask(simple_task_3);
   REQUIRE(can_add_3_opt);
   auto add_3_opt = management.addTask(simple_task_3);
-  auto add_3_metrics = management.getCurrentMetrics();
+  auto add_3_metrics = management.getFinalMetrics();
 
   REQUIRE(add_3_metrics.getMakespan() == add_2_metrics.getMakespan() + add_3_metrics.getTime());
 }
@@ -344,7 +344,7 @@ TEST_CASE("SimpleOrderManagement Two Transport Orders in one Task",
   REQUIRE(add_1_opt);
 
   // current metrics of the second order
-  auto add_1_metrics = management.getCurrentMetrics();
+  auto add_1_metrics = management.getFinalMetrics();
   REQUIRE(add_1_metrics.empty_travel_distance == 10);
   REQUIRE(add_1_metrics.empty_travel_time == 11);
   REQUIRE(add_1_metrics.getMakespan() == 58);
@@ -371,7 +371,7 @@ TEST_CASE("SimpleOrderManagement One Transport, Move, and Action Order in one Ta
   REQUIRE_THROWS(management.addTask(task_1));
 
   // current metrics should be unchanged
-  auto metrics = management.getCurrentMetrics();
+  auto metrics = management.getFinalMetrics();
   REQUIRE(metrics.getTime() == 0);
   REQUIRE(metrics.loaded_travel_time == 0);
   REQUIRE(metrics.empty_travel_time == 0);
@@ -385,7 +385,7 @@ TEST_CASE("SimpleOrderManagement One Transport, Move, and Action Order in one Ta
 
   auto add_opt = management.addTask(task_2);
   REQUIRE(add_opt);
-  auto add_metrics = management.getCurrentMetrics();
+  auto add_metrics = management.getFinalMetrics();
 
   // current metrics of the action order
   REQUIRE(add_metrics.action_time == 7);
@@ -423,11 +423,11 @@ TEST_CASE("Simple Order Management Three Simple Transport Orders with time delay
   Task simple_task_3("simple_task_3", {simple_to_3}, {});
 
   auto add_1_opt = management.addTask(simple_task_1);
-  auto add_1_metrics = management.getCurrentMetrics();
+  auto add_1_metrics = management.getFinalMetrics();
 
   management.setCurrentTime(10);
   auto add_2_opt = management.addTask(simple_task_2);
-  auto add_2_metrics = management.getCurrentMetrics();
+  auto add_2_metrics = management.getFinalMetrics();
 
   REQUIRE(add_1_opt);
   REQUIRE(add_2_opt);
@@ -446,7 +446,7 @@ TEST_CASE("Simple Order Management Three Simple Transport Orders with time delay
   auto can_add_3_opt = management.canAddTask(simple_task_3);
   REQUIRE(can_add_3_opt);
   auto add_3_opt = management.addTask(simple_task_3);
-  auto add_3_metrics = management.getCurrentMetrics();
+  auto add_3_metrics = management.getFinalMetrics();
 
   // makespan should have been affected by the current time
   REQUIRE(add_3_metrics.getMakespan() == add_3_metrics.getTime() + 100);

--- a/daisi/tests/unittests/cpps/order_management/simple_order_management_test.cpp
+++ b/daisi/tests/unittests/cpps/order_management/simple_order_management_test.cpp
@@ -1,0 +1,454 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "cpps/logical/order_management/simple_order_management.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+
+using namespace daisi::material_flow;
+using namespace daisi::cpps;
+using namespace daisi::cpps::logical;
+using namespace daisi::cpps::mrta::model;
+
+AmrDescription buildBasicAmrDescription() {
+  AmrKinematics kinematics{1, 0, 1, 1};
+  AmrProperties properties{};
+  AmrPhysicalProperties physical_properties{50, {0.5, 0.5, 0.5}};
+  AmrLoadHandlingUnit load_hanling_unit{
+      7, 8, {50, mrta::model::LoadCarrier{LoadCarrier::kEuroBox}}};
+
+  return AmrDescription{42, kinematics, properties, physical_properties, load_hanling_unit};
+}
+
+Topology buildBasicTopology() { return Topology{{20, 20, 0}}; }
+
+daisi::util::Position p0(0, 0);
+daisi::util::Position p1(10, 0);
+daisi::util::Position p2(10, 10);
+daisi::util::Position p3(0, 10);
+daisi::util::Position p4(5, 10);
+daisi::util::Position p5(20, 0);
+daisi::util::Position p6(20, 10);
+
+TEST_CASE("SimpleOrderManagement Empty Tasks", "[adding and removing vertices]") {
+  // arrange
+  auto current_pose = daisi::util::Pose(daisi::util::Position(10, 10));
+  SimpleOrderManagement management(buildBasicAmrDescription(), buildBasicTopology(), current_pose);
+
+  // assert preconditions
+  REQUIRE(!management.hasTasks());
+  REQUIRE_THROWS(management.getCurrentTask());
+  REQUIRE(!management.setNextTask());
+
+  // empty task
+  Task task_empty("task1", {}, {});
+  REQUIRE_THROWS(management.canAddTask(task_empty));
+  REQUIRE_THROWS(management.addTask(task_empty));
+
+  // empty task with follow ups
+  Task task_empty_with_follow_ups("task2", {}, {"task1", "task3"});
+  REQUIRE_THROWS(management.canAddTask(task_empty_with_follow_ups));
+  REQUIRE_THROWS(management.addTask(task_empty_with_follow_ups));
+}
+
+TEST_CASE("SimpleOrderManagement One Simple Transport Order", "[adding and removing vertices]") {
+  // arrange
+  auto current_pose = daisi::util::Pose(p0);
+  SimpleOrderManagement management(buildBasicAmrDescription(), buildBasicTopology(), current_pose);
+
+  // assert preconditions
+  REQUIRE(!management.hasTasks());
+  REQUIRE_THROWS(management.getCurrentTask());
+  REQUIRE(!management.setNextTask());
+
+  // one transport order
+  TransportOrderStep pickup1("tos1", {}, Location("0x0", "type", p1));
+  TransportOrderStep delivery1("tos2", {}, Location("0x1", "type", p2));
+  TransportOrder simple_to("simple_to", {pickup1}, delivery1);
+  Task simple_task("simple_task", {simple_to}, {});
+
+  // act
+  auto opt_result = management.canAddTask(simple_task);
+  REQUIRE(opt_result);
+  auto metrics = management.getCurrentMetrics();
+  REQUIRE(metrics.getTime() == 0);
+  REQUIRE(metrics.loaded_travel_time == 0);
+  REQUIRE(metrics.empty_travel_time == 0);
+  REQUIRE(metrics.action_time == 0);
+  REQUIRE(metrics.loaded_travel_distance == 0);
+  REQUIRE(metrics.empty_travel_distance == 0);
+  REQUIRE(metrics.getDistance() == 0);
+  REQUIRE(metrics.getMakespan() == 0);
+
+  // assert management states not changed
+  REQUIRE(!management.hasTasks());
+  REQUIRE_THROWS(management.getCurrentTask());
+  REQUIRE(!management.setNextTask());
+
+  // act
+  auto add_results = management.addTask(simple_task);
+  REQUIRE(add_results);
+  metrics = management.getCurrentMetrics();
+  // assert metrics results
+  REQUIRE(metrics.loaded_travel_time == 11);
+  REQUIRE(metrics.empty_travel_time == 11);
+  REQUIRE(metrics.action_time == 15);
+  REQUIRE(metrics.loaded_travel_distance == 10);
+  REQUIRE(metrics.empty_travel_distance == 10);
+  REQUIRE(metrics.getTime() == 37);
+  REQUIRE(metrics.getDistance() == 20);
+  REQUIRE(metrics.getMakespan() == 37);
+
+  // assert
+  REQUIRE(management.setNextTask());
+  REQUIRE(management.hasTasks());
+  auto task = management.getCurrentTask();
+  REQUIRE(task.getName() == "simple_task");
+
+  REQUIRE(!management.setNextTask());
+  REQUIRE(!management.hasTasks());
+}
+
+TEST_CASE("SimpleOrderManagement Two Simple Transport Orders", "[adding and removing vertices]") {
+  // arrange
+  auto current_pose = daisi::util::Pose(p0);
+  SimpleOrderManagement management(buildBasicAmrDescription(), buildBasicTopology(), current_pose);
+
+  // transport order 1
+  TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p1));
+  TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
+  TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
+  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+
+  // transport order 2
+  TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p4));
+  TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p3));
+  TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
+  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+
+  // can add tests
+  auto can_add_1 = management.canAddTask(simple_task_1);
+  REQUIRE(can_add_1);
+
+  auto can_add_2 = management.canAddTask(simple_task_2);
+  REQUIRE(can_add_2);
+  auto metrics = management.getCurrentMetrics();
+  REQUIRE(metrics.getTime() == 0);
+  REQUIRE(metrics.loaded_travel_time == 0);
+  REQUIRE(metrics.empty_travel_time == 0);
+  REQUIRE(metrics.action_time == 0);
+  REQUIRE(metrics.loaded_travel_distance == 0);
+  REQUIRE(metrics.empty_travel_distance == 0);
+  REQUIRE(metrics.getDistance() == 0);
+  REQUIRE(metrics.getMakespan() == 0);
+
+  // adding task 1
+  REQUIRE(!management.hasTasks());
+  auto add_1_result = management.addTask(simple_task_1);
+  REQUIRE(add_1_result);
+
+  auto add_1_metrics = management.getCurrentMetrics();
+
+  // can add task 2 after 1
+  auto can_add_2_2 = management.canAddTask(simple_task_2);
+  REQUIRE(can_add_2_2);
+
+  // adding task 2
+  auto add_2_result = management.addTask(simple_task_2);
+  REQUIRE(add_2_result);
+
+  auto add_2_metrics = management.getCurrentMetrics();
+  REQUIRE(add_2_metrics.loaded_travel_time == 6);
+  REQUIRE(add_2_metrics.empty_travel_time == 6);
+  REQUIRE(add_2_metrics.action_time == 15);
+  REQUIRE(add_2_metrics.loaded_travel_distance == 5);
+  REQUIRE(add_2_metrics.empty_travel_distance == 5);
+  REQUIRE(add_2_metrics.getTime() == 27);
+  REQUIRE(add_2_metrics.getDistance() == 10);
+  REQUIRE(add_2_metrics.getMakespan() == 64);
+
+  // checking management states after insertions
+  REQUIRE(!management.hasTasks());
+  REQUIRE(management.setNextTask());
+  auto first_task = management.getCurrentTask();
+  REQUIRE(first_task.getName() == "simple_task_1");
+  REQUIRE(management.hasTasks());
+
+  REQUIRE(management.setNextTask());
+  auto second_task = management.getCurrentTask();
+  REQUIRE(second_task.getName() == "simple_task_2");
+  REQUIRE(management.hasTasks());
+
+  REQUIRE(!management.setNextTask());
+  REQUIRE(!management.hasTasks());
+}
+
+TEST_CASE("SimpleOrderManagement Two Simple Transport Orders multiple times",
+          "[adding and removing vertices]") {
+  // arrange
+  auto current_pose = daisi::util::Pose(p0);
+  SimpleOrderManagement management(buildBasicAmrDescription(), buildBasicTopology(), current_pose);
+
+  // transport order 1
+  TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p1));
+  TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
+  TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
+  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+
+  // transport order 2
+  TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p4));
+  TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p3));
+  TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
+  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+
+  // adding and removing task 2
+  REQUIRE(!management.hasTasks());
+  auto add_2_1_result = management.addTask(simple_task_2);
+  REQUIRE(add_2_1_result);
+  auto add_2_1_metrics = management.getCurrentMetrics();
+  REQUIRE(management.setNextTask());
+  auto second_task = management.getCurrentTask();
+  REQUIRE(second_task.getName() == "simple_task_2");
+  REQUIRE(management.hasTasks());
+  REQUIRE(!management.setNextTask());
+  REQUIRE(!management.hasTasks());
+
+  // adding task 1
+  auto add_1_result = management.addTask(simple_task_1);
+  REQUIRE(add_1_result);
+
+  auto add_1_metrics = management.getCurrentMetrics();
+  auto makespan_task_1 = add_1_metrics.getMakespan();
+
+  // makespan of task 1 must depend on the makespan of task 2
+  REQUIRE(makespan_task_1 >= add_2_1_metrics.getMakespan() + add_1_metrics.getTime());
+
+  // can add task 2 after 1
+  auto can_add_2_2 = management.canAddTask(simple_task_2);
+  REQUIRE(can_add_2_2);
+
+  // adding task 2
+  auto add_2_2_result = management.addTask(simple_task_2);
+  REQUIRE(add_2_2_result);
+
+  auto add_2_2_metrics = management.getCurrentMetrics();
+  REQUIRE(add_2_2_metrics.loaded_travel_time == 6);
+  REQUIRE(add_2_2_metrics.empty_travel_time == 6);
+  REQUIRE(add_2_2_metrics.action_time == 15);
+  REQUIRE(add_2_2_metrics.loaded_travel_distance == 5);
+  REQUIRE(add_2_2_metrics.empty_travel_distance == 5);
+  REQUIRE(add_2_2_metrics.getTime() == 27);
+  REQUIRE(add_2_2_metrics.getDistance() == 10);
+  REQUIRE(add_2_2_metrics.getMakespan() == makespan_task_1 + 27);
+
+  // compare with metrics of task 2 from before inserting task 1
+  REQUIRE(add_2_2_metrics.empty_travel_distance < add_2_1_metrics.empty_travel_distance);
+  REQUIRE(add_2_2_metrics.empty_travel_time < add_2_1_metrics.empty_travel_time);
+  REQUIRE(add_2_2_metrics.loaded_travel_distance == add_2_1_metrics.loaded_travel_distance);
+  REQUIRE(add_2_2_metrics.loaded_travel_time == add_2_1_metrics.loaded_travel_time);
+  REQUIRE(add_2_2_metrics.action_time == add_2_1_metrics.action_time);
+  REQUIRE(add_2_2_metrics.getMakespan() > add_2_1_metrics.getMakespan());
+
+  // checking management states after insertions
+  REQUIRE(!management.hasTasks());
+  REQUIRE(management.setNextTask());
+  auto first_task = management.getCurrentTask();
+  REQUIRE(first_task.getName() == "simple_task_1");
+  REQUIRE(management.hasTasks());
+
+  REQUIRE(management.setNextTask());
+  auto second_task_2 = management.getCurrentTask();
+  REQUIRE(second_task_2.getName() == "simple_task_2");
+  REQUIRE(management.hasTasks());
+
+  REQUIRE(!management.setNextTask());
+  REQUIRE(!management.hasTasks());
+}
+
+TEST_CASE("SimpleOrderManagement Three Simple Transport Orders", "[adding and removing vertices]") {
+  // arrange
+  auto current_pose = daisi::util::Pose(p0);
+  SimpleOrderManagement management(buildBasicAmrDescription(), buildBasicTopology(), current_pose);
+
+  // transport order 1
+  TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p3));
+  TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
+  TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
+  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+
+  // transport order 2
+  TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p6));
+  TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p5));
+  TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
+  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+
+  // transport order 3
+  TransportOrderStep pickup_3("tos1_3", {}, Location("0x4", "type", p1));
+  TransportOrderStep delivery_3("tos2_3", {}, Location("0x5", "type", p0));
+  TransportOrder simple_to_3("simple_to_3", {pickup_3}, delivery_3);
+  Task simple_task_3("simple_task_3", {simple_to_3}, {});
+
+  auto add_1_opt = management.addTask(simple_task_1);
+  auto add_1_metrics = management.getCurrentMetrics();
+  auto add_2_opt = management.addTask(simple_task_2);
+  auto add_2_metrics = management.getCurrentMetrics();
+
+  REQUIRE(add_1_opt);
+  REQUIRE(add_2_opt);
+
+  REQUIRE(add_1_metrics.getDistance() == add_2_metrics.getDistance());
+  REQUIRE(add_1_metrics.getTime() == add_2_metrics.getTime());
+  REQUIRE(add_2_metrics.getMakespan() == add_1_metrics.getMakespan() + add_2_metrics.getTime());
+
+  // add task 3, should come after task 2
+  auto can_add_3_opt = management.canAddTask(simple_task_3);
+  REQUIRE(can_add_3_opt);
+  auto add_3_opt = management.addTask(simple_task_3);
+  auto add_3_metrics = management.getCurrentMetrics();
+
+  REQUIRE(add_3_metrics.getMakespan() == add_2_metrics.getMakespan() + add_3_metrics.getTime());
+}
+
+TEST_CASE("SimpleOrderManagement Two Transport Orders in one Task",
+          "[adding and removing vertices]") {
+  // arrange
+  auto current_pose = daisi::util::Pose(p0);
+  SimpleOrderManagement management(buildBasicAmrDescription(), buildBasicTopology(), current_pose);
+
+  // transport order 1
+  TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p0));
+  TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p1));
+  TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
+
+  TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p2));
+  TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p4));
+  TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
+
+  Task task_1("task_1", {simple_to_1, simple_to_2}, {});
+
+  auto add_1_opt = management.addTask(task_1);
+  REQUIRE(add_1_opt);
+
+  // current metrics of the second order
+  auto add_1_metrics = management.getCurrentMetrics();
+  REQUIRE(add_1_metrics.empty_travel_distance == 10);
+  REQUIRE(add_1_metrics.empty_travel_time == 11);
+  REQUIRE(add_1_metrics.getMakespan() == 58);
+}
+
+TEST_CASE("SimpleOrderManagement One Transport, Move, and Action Order in one Task",
+          "[adding and removing vertices]") {
+  // arrange
+  auto current_pose = daisi::util::Pose(p0);
+  SimpleOrderManagement management(buildBasicAmrDescription(), buildBasicTopology(), current_pose);
+
+  TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p0));
+  TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p1));
+  TransportOrder to_1("to_1", {pickup_1}, delivery_1);
+
+  MoveOrderStep mos("mos", {}, Location("0x2", "type", p2));
+  MoveOrder mo_1("mo", mos);
+
+  ActionOrderStep aos("aos", {{"load", "load"}});
+  ActionOrder ao_1("ao", aos);
+
+  // try to add an illformed task, since a MoveOrder should not be the first order
+  Task task_1("task_1", {mo_1, to_1, ao_1}, {});
+  REQUIRE_THROWS(management.addTask(task_1));
+
+  // current metrics should be unchanged
+  auto metrics = management.getCurrentMetrics();
+  REQUIRE(metrics.getTime() == 0);
+  REQUIRE(metrics.loaded_travel_time == 0);
+  REQUIRE(metrics.empty_travel_time == 0);
+  REQUIRE(metrics.action_time == 0);
+  REQUIRE(metrics.loaded_travel_distance == 0);
+  REQUIRE(metrics.empty_travel_distance == 0);
+  REQUIRE(metrics.getDistance() == 0);
+  REQUIRE(metrics.getMakespan() == 0);
+
+  Task task_2("task_2", {to_1, mo_1, ao_1}, {});
+
+  auto add_opt = management.addTask(task_2);
+  REQUIRE(add_opt);
+  auto add_metrics = management.getCurrentMetrics();
+
+  // current metrics of the action order
+  REQUIRE(add_metrics.action_time == 7);
+  REQUIRE(add_metrics.empty_travel_distance == 0);
+  REQUIRE(add_metrics.empty_travel_time == 0);
+  REQUIRE(add_metrics.loaded_travel_distance == 0);
+  REQUIRE(add_metrics.loaded_travel_time == 0);
+
+  // makespan + time for the previous orders
+  REQUIRE(add_metrics.getMakespan() >= add_metrics.getTime() + 41);
+}
+
+TEST_CASE("Simple Order Management Three Simple Transport Orders with time delay",
+          "[adding and removing vertices]") {
+  // arrange
+  auto current_pose = daisi::util::Pose(p0);
+  SimpleOrderManagement management(buildBasicAmrDescription(), buildBasicTopology(), current_pose);
+
+  // transport order 1
+  TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p3));
+  TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
+  TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
+  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+
+  // transport order 2
+  TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p6));
+  TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p5));
+  TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
+  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+
+  // transport order 3
+  TransportOrderStep pickup_3("tos1_3", {}, Location("0x4", "type", p1));
+  TransportOrderStep delivery_3("tos2_3", {}, Location("0x5", "type", p0));
+  TransportOrder simple_to_3("simple_to_3", {pickup_3}, delivery_3);
+  Task simple_task_3("simple_task_3", {simple_to_3}, {});
+
+  auto add_1_opt = management.addTask(simple_task_1);
+  auto add_1_metrics = management.getCurrentMetrics();
+
+  management.setCurrentTime(10);
+  auto add_2_opt = management.addTask(simple_task_2);
+  auto add_2_metrics = management.getCurrentMetrics();
+
+  REQUIRE(add_1_opt);
+  REQUIRE(add_2_opt);
+
+  REQUIRE(add_1_metrics.getDistance() == add_2_metrics.getDistance());
+  REQUIRE(add_1_metrics.getTime() == add_2_metrics.getTime());
+
+  // makespan should not have been affected by the current time
+  REQUIRE(add_2_metrics.getMakespan() == add_1_metrics.getMakespan() + add_2_metrics.getTime());
+
+  // current time should not be decreased
+  REQUIRE_THROWS(management.setCurrentTime(0));
+
+  management.setCurrentTime(100);
+  // add task 3, should come after task 2
+  auto can_add_3_opt = management.canAddTask(simple_task_3);
+  REQUIRE(can_add_3_opt);
+  auto add_3_opt = management.addTask(simple_task_3);
+  auto add_3_metrics = management.getCurrentMetrics();
+
+  // makespan should have been affected by the current time
+  REQUIRE(add_3_metrics.getMakespan() == add_3_metrics.getTime() + 100);
+  REQUIRE(add_3_metrics.getMakespan() > add_2_metrics.getMakespan() + add_3_metrics.getTime());
+}


### PR DESCRIPTION
Closes #13 

# Proposed Changes

Introduce an order management for the amr logical agent to handle task assignments by a central optimizer. Simply insert each assignment into a fifo queue.

Include tests and documentation.

# Definition of Done
- [X] Feature is implemented
- [X] No known bugs that stops the correct execution
- [ ] CI / CD pipeline passed
- [X] The code guidelines were followed
- [X] Unit and / or Integration tests for the new feature
- [ ] New feature was added to the documentation


