### PR TITLE
feat(cpps): Introduce centralized task assignment

### DIFF
--- a/cppcheck.conf
+++ b/cppcheck.conf
@@ -28,6 +28,9 @@ constParameter:daisi/src/path_planning/message/misc/reached_goal.h
 constParameter:daisi/src/path_planning/message/handover_message.h
 constParameter:daisi/src/path_planning/consensus/paxos/message/response_message.h
 
+# avoid assignment inside initiatorList for readability
+useInitializationList:daisi/src/cpps/logical/algorithms/disposition/centralized_initiator.cpp
+
 # Suppress third party
 *:third_party/*
 *:minhton/third_party/*

--- a/daisi/src/cpps/amr/model/amr_load_carrier.cpp
+++ b/daisi/src/cpps/amr/model/amr_load_carrier.cpp
@@ -51,6 +51,8 @@ std::string LoadCarrier::getTypeAsString() const {
   return "invalid";
 }
 
+bool LoadCarrier::isValid() const { return type_ != LoadCarrier::Types::kNoLoadCarrierType; }
+
 LoadCarrier::Types LoadCarrier::getTypeFromString(const std::string &type_name) {
   if (LoadCarrier::string_to_type_.find(type_name) != LoadCarrier::string_to_type_.end()) {
     return LoadCarrier::string_to_type_.at(type_name);

--- a/daisi/src/cpps/amr/model/amr_load_carrier.h
+++ b/daisi/src/cpps/amr/model/amr_load_carrier.h
@@ -49,6 +49,7 @@ public:
   friend std::ostream &operator<<(std::ostream &os, const LoadCarrier &l);
 
   std::string getTypeAsString() const;
+  bool isValid() const;
 
   SERIALIZE(type_);
 

--- a/daisi/src/cpps/amr/model/amr_static_ability.cpp
+++ b/daisi/src/cpps/amr/model/amr_static_ability.cpp
@@ -29,6 +29,10 @@ const LoadCarrier &AmrStaticAbility::getLoadCarrier() const { return load_carrie
 
 float AmrStaticAbility::getMaxPayloadWeight() const { return max_payload_weight_kg_; }
 
+bool AmrStaticAbility::isValid() const {
+  return (load_carrier_.isValid() && max_payload_weight_kg_ > 0);
+}
+
 bool operator==(const AmrStaticAbility &a1, const AmrStaticAbility &a2) {
   return a1.getLoadCarrier() == a2.getLoadCarrier() &&
          a1.getMaxPayloadWeight() == a2.getMaxPayloadWeight();

--- a/daisi/src/cpps/amr/model/amr_static_ability.h
+++ b/daisi/src/cpps/amr/model/amr_static_ability.h
@@ -36,6 +36,7 @@ public:
 
   const LoadCarrier &getLoadCarrier() const;
   float getMaxPayloadWeight() const;
+  bool isValid() const;
 
   friend bool operator==(const AmrStaticAbility &a1, const AmrStaticAbility &a2);
   friend bool operator!=(const AmrStaticAbility &a1, const AmrStaticAbility &a2);

--- a/daisi/src/cpps/common/scenariofile/cpps_scenariofile.h
+++ b/daisi/src/cpps/common/scenariofile/cpps_scenariofile.h
@@ -49,11 +49,13 @@ struct AlgorithmScenario {
   const std::unordered_map<std::string, logical::AlgorithmType>
       assignment_strategy_to_initiator_algorithm_type = {
           {"iterated_auction", logical::AlgorithmType::kIteratedAuctionDispositionInitiator},
+          {"round_robin", logical::AlgorithmType::kRoundRobinInitiator},
   };
 
   const std::unordered_map<std::string, logical::AlgorithmType>
       assignment_strategy_to_participant_algorithm_type = {
-          {"iterated_auction", logical::AlgorithmType::kIteartedAuctionDispositionParticipant},
+          {"iterated_auction", logical::AlgorithmType::kIteratedAuctionDispositionParticipant},
+          {"round_robin", logical::AlgorithmType::kRoundRobinParticipant},
   };
 
   void parse(YAML::Node node) { SERIALIZE_VAR(assignment_strategy); }

--- a/daisi/src/cpps/logical/algorithms/CMakeLists.txt
+++ b/daisi/src/cpps/logical/algorithms/CMakeLists.txt
@@ -22,4 +22,8 @@ target_link_libraries(daisi_cpps_logical_algorithms_algorithm_interface
     daisi_cpps_logical_message_auction_based_iteration_notification
     daisi_cpps_logical_message_auction_based_winner_notification
     daisi_cpps_logical_message_auction_based_winner_response
+    daisi_cpps_logical_message_central_allocation_assignment_notification
+    daisi_cpps_logical_message_central_allocation_assignment_response
+    daisi_cpps_logical_message_central_allocation_status_update
+    daisi_cpps_logical_message_central_allocation_status_update_request
 )

--- a/daisi/src/cpps/logical/algorithms/algorithm_config.h
+++ b/daisi/src/cpps/logical/algorithms/algorithm_config.h
@@ -23,7 +23,9 @@ namespace daisi::cpps::logical {
 
 enum class AlgorithmType {
   kIteratedAuctionDispositionInitiator,
-  kIteartedAuctionDispositionParticipant
+  kIteratedAuctionDispositionParticipant,
+  kRoundRobinInitiator,
+  kRoundRobinParticipant
 };
 
 struct AlgorithmConfig {

--- a/daisi/src/cpps/logical/algorithms/algorithm_interface.h
+++ b/daisi/src/cpps/logical/algorithms/algorithm_interface.h
@@ -25,6 +25,10 @@
 #include "cpps/logical/message/auction_based/iteration_notification.h"
 #include "cpps/logical/message/auction_based/winner_notification.h"
 #include "cpps/logical/message/auction_based/winner_response.h"
+#include "cpps/logical/message/central_allocation/assignment_notification.h"
+#include "cpps/logical/message/central_allocation/assignment_response.h"
+#include "cpps/logical/message/central_allocation/status_update.h"
+#include "cpps/logical/message/central_allocation/status_update_request.h"
 #include "cpps/logical/message/serializer.h"
 #include "sola-ns3/sola_ns3_wrapper.h"
 
@@ -49,6 +53,10 @@ public:
   REGISTER_LOGICAL_MESSAGE(IterationNotification);
   REGISTER_LOGICAL_MESSAGE(WinnerNotification);
   REGISTER_LOGICAL_MESSAGE(WinnerResponse);
+  REGISTER_LOGICAL_MESSAGE(AssignmentNotification);
+  REGISTER_LOGICAL_MESSAGE(AssignmentResponse);
+  REGISTER_LOGICAL_MESSAGE(StatusUpdate);
+  REGISTER_LOGICAL_MESSAGE(StatusUpdateRequest);
 
 protected:
   std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola_;

--- a/daisi/src/cpps/logical/algorithms/disposition/CMakeLists.txt
+++ b/daisi/src/cpps/logical/algorithms/disposition/CMakeLists.txt
@@ -86,3 +86,39 @@ target_link_libraries(daisi_cpps_logical_algorithms_disposition_auction_particip
     daisi_material_flow_model_material_flow
     daisi_cpps_logical_order_management_auction_based_order_management
 )
+
+add_library(daisi_cpps_logical_algorithms_disposition_centralized_initiator STATIC)
+target_sources(daisi_cpps_logical_algorithms_disposition_centralized_initiator
+    PUBLIC
+    centralized_initiator.h
+    centralized_initiator.cpp
+)
+target_link_libraries(daisi_cpps_logical_algorithms_disposition_centralized_initiator
+    PUBLIC
+    daisi_cpps_logical_algorithms_disposition_disposition_initiator
+)
+
+add_library(daisi_cpps_logical_algorithms_disposition_centralized_participant STATIC)
+target_sources(daisi_cpps_logical_algorithms_disposition_centralized_participant
+    PUBLIC
+    centralized_participant.h
+    centralized_participant.cpp
+)
+target_link_libraries(daisi_cpps_logical_algorithms_disposition_centralized_participant
+    PUBLIC
+    daisi_cpps_logical_algorithms_disposition_disposition_participant
+)
+
+add_library(daisi_cpps_logical_algorithms_disposition_round_robin_initiator STATIC)
+target_sources(daisi_cpps_logical_algorithms_disposition_round_robin_initiator
+    PUBLIC
+    round_robin_initiator.h
+    round_robin_initiator.cpp
+)
+target_link_libraries(daisi_cpps_logical_algorithms_disposition_round_robin_initiator
+    PUBLIC
+    daisi_cpps_logical_algorithms_disposition_centralized_initiator
+    daisi_cpps_amr_model_amr_fleet
+    ns3::libcore
+    daisi_random_engine
+)

--- a/daisi/src/cpps/logical/algorithms/disposition/auction_participant_state.h
+++ b/daisi/src/cpps/logical/algorithms/disposition/auction_participant_state.h
@@ -46,13 +46,13 @@ struct AuctionParticipantTaskState {
 /// initiator.
 struct AuctionParticipantState {
   /// @brief Initiatoring the task states based on the given tasks.
-  /// @param tasks Open tasks that initially got annouced.
+  /// @param tasks Open tasks that initially got announced.
   explicit AuctionParticipantState(const std::vector<daisi::material_flow::Task> &tasks);
 
   /// @brief Storing the state of each open task. The key is the task uuid.
   std::unordered_map<std::string, AuctionParticipantTaskState> task_state_mapping;
 
-  /// @brief Task uuid of the lastest previously submitted task. If a task was submitted before, the
+  /// @brief Task uuid of the latest previously submitted task. If a task was submitted before, the
   /// initiator has still the relevant information and sending this bid again is unnecessary
   /// overhead.
   std::string previously_submitted;

--- a/daisi/src/cpps/logical/algorithms/disposition/centralized_initiator.cpp
+++ b/daisi/src/cpps/logical/algorithms/disposition/centralized_initiator.cpp
@@ -1,0 +1,98 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "centralized_initiator.h"
+
+namespace daisi::cpps::logical {
+CentralizedInitiator::CentralizedInitiator(std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
+                                           std::shared_ptr<CppsLoggerNs3> logger)
+    : DispositionInitiator(sola, logger) {
+  // create request to gain information about all active AMR's
+  sola::Request amr_request;
+  amr_request.all = true;
+  amr_request.permissive = true;
+  amr_request.request = "(servicetype == transport)";
+
+  // send request
+  amr_find_result_ = sola_->findService(amr_request);
+};
+
+void CentralizedInitiator::addMaterialFlow(
+    std::shared_ptr<material_flow::MFDLScheduler> scheduler) {
+  if (!preparation_finished_) {
+    // first material flow, finish preparation first
+    if (amr_find_result_.valid()) {
+      readAmrRequestFuture();
+    } else {
+      throw std::runtime_error("Future is not ready yet but required.");
+    }
+  }
+
+  material_flows_.push_back(*scheduler);
+  distributeMFTasks(material_flows_.size() - 1, false);
+}
+
+void CentralizedInitiator::readAmrRequestFuture() {
+  // iterate through all AMRs found
+  for (const auto &result : amr_find_result_.get()) {
+    ParticipantInfo info;
+    float max_payload = -1;
+    amr::LoadCarrier loadcarrier = amr::LoadCarrier(amr::LoadCarrier::kNoLoadCarrierType);
+
+    for (const auto &entry : result) {
+      // retreive all relevant information for ParticipantInfo
+      std::string key = std::get<0>(entry);
+      auto value = std::get<1>(entry);
+      if (key == "endpoint") {
+        info.connection_string = std::get<std::string>(value);
+      } else if (key == "loadcarriertype") {
+        loadcarrier = amr::LoadCarrier(std::get<std::string>(value));
+      } else if (key == "maxpayload") {
+        max_payload = std::get<float>(value);
+      }
+
+      if (max_payload != -1 && loadcarrier.isValid()) {
+        // all information to initialize ability were obtained
+        amr::AmrStaticAbility ability = amr::AmrStaticAbility(loadcarrier, max_payload);
+        info.ability = ability;
+      }
+    }
+    if (!info.isValid()) {
+      // something is still uninitialized
+      throw std::runtime_error("The AMR's ability and connection string should be known.");
+    }
+
+    // algorithm-specific storage of info
+    storeParticipant(info);
+  }
+
+  preparation_finished_ = true;
+}
+
+void CentralizedInitiator::logMaterialFlowOrderStatesOfTask(const material_flow::Task &task,
+                                                            const OrderStates &order_state) {
+  // log each order of the task
+  for (auto i = 0; i < task.getOrders().size(); i++) {
+    MaterialFlowOrderUpdateLoggingInfo logging_info;
+    logging_info.task = task;
+    logging_info.order_index = i;
+    logging_info.order_state = order_state;
+
+    logger_->logMaterialFlowOrderUpdate(logging_info);
+  }
+}
+
+}  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/algorithms/disposition/centralized_initiator.h
+++ b/daisi/src/cpps/logical/algorithms/disposition/centralized_initiator.h
@@ -1,0 +1,100 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_ALGORITHMS_DISPOSITION_CENTRALIZED_INITIATOR_H_
+#define DAISI_CPPS_LOGICAL_ALGORITHMS_DISPOSITION_CENTRALIZED_INITIATOR_H_
+
+#include "disposition_initiator.h"
+
+namespace daisi::cpps::logical {
+
+/// @brief Algorithm that centrally assigns tasks of incoming material flows to the
+/// corresponding centralized participants. Should be implemented by any concrete centralized task
+/// assignment algorithm.
+class CentralizedInitiator : public DispositionInitiator {
+public:
+  CentralizedInitiator(std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
+                       std::shared_ptr<CppsLoggerNs3> logger);
+  ~CentralizedInitiator() override = default;
+
+  // TODO: check if possible to restict implementation by child classes without warnings
+  //   REQUIRE_IMPLEMENTATION(AssignmentResponse);
+  //   REQUIRE_IMPLEMENTATION(StatusUpdate);
+
+  /// @brief Receive a new material flow to assign its tasks to the known participants. Push it
+  /// into material_flows_.
+  /// @param scheduler
+  void addMaterialFlow(std::shared_ptr<material_flow::MFDLScheduler> scheduler) override;
+
+protected:
+  /// @brief Helper that stores all relevant information about the task assignment participants. If
+  /// more specific information are necessary, use a struct that derives from ParticipantInfo.
+  struct ParticipantInfo {
+    /// @brief Connection string used to contact the participant.
+    std::string connection_string;
+
+    /// @brief The participant's ability. Used to check if a task's requirements are met by the AMR.
+    amr::AmrStaticAbility ability;
+
+    /// @brief Check wether all entries are initialized correctly
+    bool isValid() const { return (!connection_string.empty() && ability.isValid()); }
+  };
+
+  /// @brief Perform task assignment for all unassigned tasks of a material flow.
+  /// @param index The index position of the material flow in material_flows_.
+  /// @param previously_allocated Indicates wether the tasks of the material flow have been assigned
+  /// to participants before. In that case, only some of them may need to be reassigned.
+  virtual void distributeMFTasks(uint32_t index, bool previously_allocated) = 0;
+
+  /// @brief Add a new participant and store it locally.
+  /// @param info The necessary information about the new participant.
+  virtual void storeParticipant(ParticipantInfo &info) = 0;
+
+  /// @brief Log the new state of a task.
+  /// @param task The changed task.
+  /// @param order_state The new order state.
+  void logMaterialFlowOrderStatesOfTask(const material_flow::Task &task,
+                                        const OrderStates &order_state);
+
+  /// @brief All material flows that have been received to assign their tasks.
+  std::vector<material_flow::MFDLScheduler> material_flows_;
+
+  /// @brief Responses of task assignments that have been accepted.
+  std::vector<AssignmentResponse> assignment_acceptions_;
+
+  /// @brief Storing all delays in one place. The unit is seconds.
+  struct {
+    /// @brief Delay between assigning a task and expecting a response.
+    util::Duration wait_to_receive_assignment_response = 0.3;
+    /// @brief Delay between requesting and receiving a status update.
+    util::Duration wait_to_receive_status_update = 0.3;
+  } delays_;
+
+private:
+  /// @brief Read out all relevant information from amr_find_result_ to create ParticipantInfos for
+  /// each participant. Only used once in the preparation phase.
+  void readAmrRequestFuture();
+
+  /// @brief Gain information about the participating AMRs. Only read out in the preparation phase.
+  std::future<minhton::FindResult> amr_find_result_;
+
+  /// @brief Helper to mark wether amr_find_result_ is ready to be read. Only used in the
+  /// preparation phase.
+  bool preparation_finished_ = false;
+};
+}  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/algorithms/disposition/centralized_participant.cpp
+++ b/daisi/src/cpps/logical/algorithms/disposition/centralized_participant.cpp
@@ -1,0 +1,53 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "centralized_participant.h"
+
+namespace daisi::cpps::logical {
+
+CentralizedParticipant::CentralizedParticipant(
+    std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
+    std::shared_ptr<SimpleOrderManagement> order_management)
+    : DispositionParticipant(sola), order_management_(std::move((order_management))){};
+
+bool CentralizedParticipant::process(const AssignmentNotification &assignment_notification) {
+  const material_flow::Task assigned_task = assignment_notification.getTask();
+  if (order_management_->canAddTask(assigned_task)) {
+    order_management_->addTask(assigned_task);
+  } else {
+    throw std::runtime_error("The order management should always accept the assigned task.");
+  }
+
+  // Respond to the central allocator. Send the acception / rejection as well as the current status.
+  AssignmentResponse response(assigned_task.getUuid(), true, order_management_->getFinalMetrics(),
+                              order_management_->getExpectedEndPosition(),
+                              sola_->getConectionString());
+
+  std::string initiator_connection = assignment_notification.getInitiatorConnection();
+  sola_->sendData(serialize(response), sola::Endpoint(initiator_connection));
+  return true;
+};
+
+bool CentralizedParticipant::process(const StatusUpdateRequest &status_request) {
+  StatusUpdate update(sola_->getConectionString(), order_management_->getFinalMetrics(),
+                      order_management_->getExpectedEndPosition());
+  std::string initiator_connection = status_request.getInitiatorConnection();
+  sola_->sendData(serialize(update), sola::Endpoint(initiator_connection));
+
+  return true;
+};
+
+}  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/algorithms/disposition/centralized_participant.h
+++ b/daisi/src/cpps/logical/algorithms/disposition/centralized_participant.h
@@ -1,0 +1,45 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_ALGORITHMS_DISPOSITION_CENTRALIZED_PARTICIPANT_H_
+#define DAISI_CPPS_LOGICAL_ALGORITHMS_DISPOSITION_CENTRALIZED_PARTICIPANT_H_
+
+#include "cpps/logical/order_management/simple_order_management.h"
+#include "disposition_participant.h"
+
+namespace daisi::cpps::logical {
+
+/// @brief Participant of a centralized task assignment strategy. Since the task assignment strategy
+/// is defined by the central allocator, the participant only needs to handle new task assignments.
+class CentralizedParticipant : public DispositionParticipant {
+public:
+  CentralizedParticipant(std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
+                         std::shared_ptr<SimpleOrderManagement> order_management);
+  ~CentralizedParticipant() override = default;
+
+  /// @brief React on new task assignment and respond to it.
+  REGISTER_IMPLEMENTATION(AssignmentNotification);
+
+  /// @brief Send a status update as a reaction.
+  REGISTER_IMPLEMENTATION(StatusUpdateRequest);
+
+private:
+  /// @brief the AMR's order management. Simply accepts a new task assignment.
+  std::shared_ptr<SimpleOrderManagement> order_management_;
+};
+}  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/algorithms/disposition/iterated_auction_disposition_participant.cpp
+++ b/daisi/src/cpps/logical/algorithms/disposition/iterated_auction_disposition_participant.cpp
@@ -23,10 +23,9 @@ namespace daisi::cpps::logical {
 
 IteratedAuctionDispositionParticipant::IteratedAuctionDispositionParticipant(
     std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
-    std::shared_ptr<OrderManagement> order_management, AmrDescription description)
+    std::shared_ptr<AuctionBasedOrderManagement> order_management, AmrDescription description)
     : DispositionParticipant(sola),
-      order_management_(
-          std::move(std::dynamic_pointer_cast<AuctionBasedOrderManagement>(order_management))),
+      order_management_(std::move(order_management)),
       description_(std::move(description)) {
   auto topic = AmrFleet::get().getTopicForAbility(description_.getLoadHandling().getAbility());
   sola_->subscribeTopic(topic);

--- a/daisi/src/cpps/logical/algorithms/disposition/iterated_auction_disposition_participant.h
+++ b/daisi/src/cpps/logical/algorithms/disposition/iterated_auction_disposition_participant.h
@@ -35,9 +35,9 @@ namespace daisi::cpps::logical {
 /// infos it has submitted.
 class IteratedAuctionDispositionParticipant : public DispositionParticipant {
 public:
-  explicit IteratedAuctionDispositionParticipant(std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
-                                                 std::shared_ptr<OrderManagement> order_management,
-                                                 AmrDescription description);
+  explicit IteratedAuctionDispositionParticipant(
+      std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
+      std::shared_ptr<AuctionBasedOrderManagement> order_management, AmrDescription description);
 
   ~IteratedAuctionDispositionParticipant() override = default;
 

--- a/daisi/src/cpps/logical/algorithms/disposition/round_robin_initiator.cpp
+++ b/daisi/src/cpps/logical/algorithms/disposition/round_robin_initiator.cpp
@@ -1,0 +1,205 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "round_robin_initiator.h"
+
+#include "cpps/amr/model/amr_fleet.h"
+#include "ns3/simulator.h"
+#include "utils/random_engine.h"
+
+namespace daisi::cpps::logical {
+RoundRobinInitiator::RoundRobinInitiator(std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
+                                         std::shared_ptr<CppsLoggerNs3> logger)
+    : CentralizedInitiator(sola, logger){};
+
+bool RoundRobinInitiator::process(const AssignmentResponse &assignment_response) {
+  if (assignment_response.doesAccept()) {
+    assignment_acceptions_.push_back(assignment_response);
+    // TODO find correct task for corresponding uuid ad log it
+  } else {
+    throw std::logic_error("The AMR should always accept the task assignment!");
+  }
+  return true;
+}
+
+// Since this is a basic algorithm, the AMR's status is not relevant here and can be ignored.
+bool RoundRobinInitiator::process(const StatusUpdate &status_update) { return true; }
+
+void RoundRobinInitiator::storeParticipant(ParticipantInfo &info) {
+  // transform base class ParticipantInfo into concrete ParticipantInfoRoundRobin and store it
+  ParticipantInfoRoundRobin info_rr;
+  info_rr.ability = info.ability;
+  info_rr.connection_string = info.connection_string;
+  participants_per_ability_[info_rr.ability].push(info_rr);
+}
+
+void RoundRobinInitiator::logMaterialFlowContent(const std::string &material_flow_uuid) {
+  // only roughly implemented since the MFDLScheduler is not available yet
+  auto material_flow = find_if(material_flows_.begin(), material_flows_.end(),
+                               [&material_flow_uuid](const auto &mf_scheduler) {
+                                 // placeholder
+                                 return true;
+                               });
+  // TODO: Log tasks and orders of the MFDLScheduler with the passed uuid
+}
+
+void RoundRobinInitiator::distributeMFTasks(uint32_t index, bool previously_allocated) {
+  // TODO: filter the wanted information out from the MFDLScheduler
+
+  // hardcoded tasks for testing
+  material_flow::TransportOrderStep pickup1(
+      "tos11", {}, material_flow::Location("0x0", "type", util::Position(10, 10)));
+  material_flow::TransportOrderStep delivery1(
+      "tos12", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
+  material_flow::TransportOrder to1({pickup1}, delivery1);
+  material_flow::Task task1("task1", {to1}, {});
+
+  material_flow::TransportOrderStep pickup2(
+      "tos21", {}, material_flow::Location("0x0", "type", util::Position(20, 10)));
+  material_flow::TransportOrderStep delivery2(
+      "tos22", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
+  material_flow::TransportOrder to2({pickup2}, delivery2);
+  material_flow::Task task2("task2", {to2}, {});
+
+  material_flow::TransportOrderStep pickup3(
+      "tos31", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
+  material_flow::TransportOrderStep delivery3(
+      "tos32", {}, material_flow::Location("0x0", "type", util::Position(5, 5)));
+  material_flow::TransportOrder to3({pickup3}, delivery3);
+  material_flow::Task task3("task3", {to3}, {});
+
+  material_flow::TransportOrderStep pickup4(
+      "tos41", {}, material_flow::Location("0x0", "type", util::Position(0, 10)));
+  material_flow::TransportOrderStep delivery4(
+      "tos42", {}, material_flow::Location("0x0", "type", util::Position(15, 15)));
+  material_flow::TransportOrder to4({pickup4}, delivery4);
+  material_flow::Task task4("task4", {to4}, {});
+
+  material_flow::TransportOrder to5({pickup2}, delivery4);
+  material_flow::Task task5("task5", {to5}, {});
+
+  material_flow::TransportOrder to6({pickup1}, delivery1);
+  material_flow::Task task6("task6", {to6}, {});
+
+  material_flow::TransportOrder to7({pickup3}, delivery2);
+  material_flow::Task task7("task7", {to7}, {});
+
+  amr::AmrStaticAbility ability1(amr::LoadCarrier(amr::LoadCarrier::Types::kPackage), 20);
+  amr::AmrStaticAbility ability2(amr::LoadCarrier(amr::LoadCarrier::Types::kEuroBox), 20);
+  amr::AmrStaticAbility ability3(amr::LoadCarrier(amr::LoadCarrier::Types::kPackage), 40);
+
+  task1.setAbilityRequirement(ability1);
+  task2.setAbilityRequirement(ability2);
+  task3.setAbilityRequirement(ability3);
+  task4.setAbilityRequirement(ability3);
+  task5.setAbilityRequirement(ability1);
+  task6.setAbilityRequirement(ability3);
+  task7.setAbilityRequirement(ability1);
+
+  std::string mf_id = "test_id";
+  std::vector<material_flow::Task> tasks = {task1, task2, task3, task4, task5, task6, task7};
+
+  // check wether all tasks have to be distributed, or only parts of it
+  if (previously_allocated) {
+    tasks = unallocated_tasks_per_mf_[mf_id];
+  } else {
+    unallocated_tasks_per_mf_[mf_id] = tasks;
+  }
+  for (auto &task : tasks) {
+    assignTask(task);
+  }
+  ns3::Simulator::Schedule(ns3::Seconds(delays_.wait_to_receive_assignment_response),
+                           &RoundRobinInitiator::processAssignmentAcceptions, this, index);
+}
+
+void RoundRobinInitiator::assignTask(const material_flow::Task &task) {
+  std::shared_ptr<RoundRobinInitiator::ParticipantInfoRoundRobin> chosen_participant =
+      chooseParticipantForTask(task);
+
+  // inform about task assignment
+  AssignmentNotification assignment_notification(task, sola_->getConectionString());
+  sola_->sendData(serialize(assignment_notification),
+                  sola::Endpoint(chosen_participant->connection_string));
+
+  // update participant and priority queue
+  chosen_participant->assignment_counter++;
+  participants_per_ability_[chosen_participant->ability].pop();
+  participants_per_ability_[chosen_participant->ability].push(*chosen_participant);
+}
+
+std::shared_ptr<RoundRobinInitiator::ParticipantInfoRoundRobin>
+RoundRobinInitiator::chooseParticipantForTask(const material_flow::Task &task) {
+  // discover participants which can execute the task
+  std::vector<daisi::cpps::amr::AmrStaticAbility> fitting_abilities =
+      AmrFleet::get().getFittingExistingAbilities(task.getAbilityRequirement());
+  std::vector<ParticipantInfoRoundRobin> possible_candidates;
+  if (fitting_abilities.empty()) {
+    throw std::runtime_error("The task requirements cannot be met by any participant.");
+  }
+
+  for (const auto &ability : fitting_abilities) {
+    // observe the participant with the highest priority per ability
+    ParticipantInfoRoundRobin first_participant = participants_per_ability_[ability].top();
+
+    // check wether the priority is high enough to become a possible candidate for the task
+    if (possible_candidates.empty() ||
+        first_participant.assignment_counter <= possible_candidates[0].assignment_counter) {
+      if (!possible_candidates.empty() &&
+          first_participant.assignment_counter < possible_candidates[0].assignment_counter) {
+        // higher prio than all other participants so far
+        possible_candidates.clear();
+      }
+      possible_candidates.push_back(first_participant);
+    }
+  }
+  if (possible_candidates.empty()) {
+    throw std::runtime_error("No AMR matches the task requirements");
+  }
+  int random_index = 0;
+  if (possible_candidates.size() > 1) {
+    // choose AMR randomly
+    std::uniform_int_distribution<uint64_t> dist(0, possible_candidates.size());
+    random_index = dist(daisi::global_random_engine);
+  }
+  auto chosen_participant =
+      std::make_shared<ParticipantInfoRoundRobin>(possible_candidates[random_index]);
+
+  return chosen_participant;
+}
+
+void RoundRobinInitiator::processAssignmentAcceptions(uint32_t index) {
+  // TODO: find the correct mf_id with the passed index when MFDLScheduler available
+
+  // id for testing
+  std::string mf_id = "test_id";
+
+  auto distributed_tasks = unallocated_tasks_per_mf_[mf_id];
+  // remove tasks where we received an acception for
+  for (auto &message : assignment_acceptions_) {
+    auto task_it = std::find_if(distributed_tasks.begin(), distributed_tasks.end(),
+                                [message](const material_flow::Task &task) -> bool {
+                                  return task.getUuid() == message.getTaskUuid();
+                                });
+    assert(task_it != distributed_tasks.end());
+    distributed_tasks.erase(task_it);
+  }
+  if (!distributed_tasks.empty()) {
+    // reassign failed tasks
+    distributeMFTasks(index, true);
+  }
+}
+
+}  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/algorithms/disposition/round_robin_initiator.h
+++ b/daisi/src/cpps/logical/algorithms/disposition/round_robin_initiator.h
@@ -1,0 +1,99 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_ALGORITHMS_DISPOSITION_ROUND_ROBIN_INITIATOR_H_
+#define DAISI_CPPS_LOGICAL_ALGORITHMS_DISPOSITION_ROUND_ROBIN_INITIATOR_H_
+
+#include <map>
+#include <queue>
+#include <random>
+#include <unordered_map>
+
+#include "centralized_initiator.h"
+
+/// @brief Modified Round Robin Algorithm that centrally assigns tasks of incoming material flows to
+/// the corresponding centralized participants.
+namespace daisi::cpps::logical {
+class RoundRobinInitiator : public CentralizedInitiator {
+public:
+  RoundRobinInitiator(std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola,
+                      std::shared_ptr<CppsLoggerNs3> logger);
+  ~RoundRobinInitiator() override = default;
+
+  /// @brief React on a participant's response to a task assignment.
+  REGISTER_IMPLEMENTATION(AssignmentResponse);
+
+  /// @brief Receive a participant's status update. For this basic algorithm, it is simply ignored.
+  REGISTER_IMPLEMENTATION(StatusUpdate);
+
+  /// @brief Log tasks and orders of a material flow.
+  void logMaterialFlowContent(const std::string &material_flow_uuid) override;
+
+private:
+  /// @brief Helper class to store all relevant infos to run the round robin assignment.
+  struct ParticipantInfoRoundRobin : public ParticipantInfo {
+    /// @brief the number of tasks that have already been assigned to the participant.
+    uint32_t assignment_counter = 0;
+
+    bool operator<(const ParticipantInfoRoundRobin &other) const {
+      return assignment_counter < other.assignment_counter;
+    }
+    bool operator>(const ParticipantInfoRoundRobin &other) const {
+      return assignment_counter > other.assignment_counter;
+    }
+  };
+
+  /// @brief Add a new participant and store it locally.
+  /// @param info The necessary information about the new participant.
+  void storeParticipant(ParticipantInfo &info) override;
+
+  /// @brief Initialize round robin task assignment for all unassigned tasks of a material flow.
+  /// @param index The index position of the material flow in material_flows_.
+  /// @param previously_allocated Indicates wether the tasks of the material flow have been assigned
+  /// to participants before. In that case, only some of them may need to be reassigned.
+  void distributeMFTasks(uint32_t index, bool previously_allocated) override;
+
+  /// @brief Perform task assignment for a given task.
+  /// @param task The task to be assigned.
+  void assignTask(const material_flow::Task &task);
+
+  /// @brief Choose one of the known participants for a given task by executing a modified round
+  /// robin strategy.
+  /// @param task The task to find a participant for.
+  /// @return A pointer onto the choosen participant.
+  std::shared_ptr<ParticipantInfoRoundRobin> chooseParticipantForTask(
+      const material_flow::Task &task);
+
+  /// @brief Iterate through all accepted task assignment. Eventually start reassigning if not all
+  /// task where accepted.
+  /// @param index The index position of the material flow in material_flows_.
+  void processAssignmentAcceptions(uint32_t index);
+
+  /// @brief Map that holds uuids of material flows as key and stores all tasks of that mf, that are
+  /// not assigned yet.
+  std::map<std::string, std::vector<material_flow::Task>> unallocated_tasks_per_mf_;
+
+  /// @brief The participants of the round robin task assignment, seperated by ability. For a round
+  /// robin behaviour, they are stored in a priority queue ordered by their assignment_counter.
+  std::unordered_map<amr::AmrStaticAbility,
+                     std::priority_queue<ParticipantInfoRoundRobin,
+                                         std::vector<ParticipantInfoRoundRobin>, std::greater<>>,
+                     amr::AmrStaticAbilityHasher>
+      participants_per_ability_;
+};
+}  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/amr/CMakeLists.txt
+++ b/daisi/src/cpps/logical/amr/CMakeLists.txt
@@ -9,11 +9,13 @@ target_link_libraries(daisi_cpps_logical_amr_amr_logical_agent
     PUBLIC
     daisi_cpps_logical_logical_agent
     daisi_cpps_logical_algorithms_disposition_iterated_auction_disposition_participant
+    daisi_cpps_logical_algorithms_disposition_centralized_participant
     daisi_cpps_amr_message_serializer
     ns3::libcore
     daisi_cpps_amr_physical_material_flow_functionality_mapping
     daisi_cpps_logical_order_management_order_management
     daisi_cpps_logical_order_management_stn_order_management
+    daisi_cpps_logical_order_management_simple_order_management
     daisi_utils
     PRIVATE
     solanet_uuid

--- a/daisi/src/cpps/logical/amr/amr_logical_agent.h
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.h
@@ -87,6 +87,7 @@ private:
 
   void sendToPhysical(std::string payload);
 
+  /// @brief make the AMR agent discoverable for findService queries
   void setServices();
 
   AmrDescription description_;

--- a/daisi/src/cpps/logical/material_flow/CMakeLists.txt
+++ b/daisi/src/cpps/logical/material_flow/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(daisi_cpps_logical_material_flow_material_flow_logical_age
     PUBLIC
     daisi_cpps_logical_logical_agent
     daisi_cpps_logical_algorithms_disposition_iterated_auction_disposition_initiator
+    daisi_cpps_logical_algorithms_disposition_round_robin_initiator
     daisi_material_flow_model_material_flow
     PRIVATE
     solanet_uuid

--- a/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.h
+++ b/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.h
@@ -70,6 +70,9 @@ protected:
   /// @brief Material flows that
   std::vector<std::shared_ptr<daisi::material_flow::MFDLScheduler>> material_flows_;
 
+  /// @brief make the mf agent discoverable for findService queries
+  void setServices();
+
 private:
   /// Simple flag to represent that the agent is still in the initialization process.
   bool waiting_for_start_ = false;

--- a/daisi/src/cpps/logical/message/CMakeLists.txt
+++ b/daisi/src/cpps/logical/message/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(auction_based)
+add_subdirectory(central_allocation)
 
 add_library(daisi_cpps_logical_message_serializer STATIC)
 target_sources(daisi_cpps_logical_message_serializer
@@ -13,6 +14,10 @@ target_link_libraries(daisi_cpps_logical_message_serializer
     daisi_cpps_logical_message_auction_based_iteration_notification
     daisi_cpps_logical_message_auction_based_winner_notification
     daisi_cpps_logical_message_auction_based_winner_response
+    daisi_cpps_logical_message_central_allocation_assignment_notification
+    daisi_cpps_logical_message_central_allocation_assignment_response
+    daisi_cpps_logical_message_central_allocation_status_update
+    daisi_cpps_logical_message_central_allocation_status_update_request
 
     PRIVATE
     solanet_serializer

--- a/daisi/src/cpps/logical/message/central_allocation/CMakeLists.txt
+++ b/daisi/src/cpps/logical/message/central_allocation/CMakeLists.txt
@@ -1,0 +1,46 @@
+add_library(daisi_cpps_logical_message_central_allocation_assignment_notification INTERFACE)
+target_sources(daisi_cpps_logical_message_central_allocation_assignment_notification
+    INTERFACE
+    assignment_notification.h
+)
+target_link_libraries(daisi_cpps_logical_message_central_allocation_assignment_notification
+    INTERFACE
+    solanet_serializer
+    daisi_material_flow_model_task
+)
+
+add_library(daisi_cpps_logical_message_central_allocation_assignment_response INTERFACE)
+target_sources(daisi_cpps_logical_message_central_allocation_assignment_response
+    INTERFACE
+    assignment_response.h
+)
+target_link_libraries(daisi_cpps_logical_message_central_allocation_assignment_response
+    INTERFACE
+    solanet_serializer
+    daisi_cpps_logical_order_management_metrics_composition
+    daisi_structure_helpers
+)
+
+add_library(daisi_cpps_logical_message_central_allocation_status_update_request INTERFACE)
+target_sources(daisi_cpps_logical_message_central_allocation_status_update_request
+    INTERFACE
+    status_update_request.h
+)
+target_link_libraries(daisi_cpps_logical_message_central_allocation_status_update_request
+    INTERFACE
+    solanet_serializer
+)
+
+add_library(daisi_cpps_logical_message_central_allocation_status_update INTERFACE)
+target_sources(daisi_cpps_logical_message_central_allocation_status_update
+    INTERFACE
+    status_update.h
+)
+target_link_libraries(daisi_cpps_logical_message_central_allocation_status_update
+    INTERFACE
+    solanet_serializer
+    daisi_cpps_logical_order_management_metrics_composition
+    daisi_structure_helpers
+)
+
+    

--- a/daisi/src/cpps/logical/message/central_allocation/CMakeLists.txt
+++ b/daisi/src/cpps/logical/message/central_allocation/CMakeLists.txt
@@ -42,5 +42,3 @@ target_link_libraries(daisi_cpps_logical_message_central_allocation_status_updat
     daisi_cpps_logical_order_management_metrics_composition
     daisi_structure_helpers
 )
-
-    

--- a/daisi/src/cpps/logical/message/central_allocation/assignment_notification.h
+++ b/daisi/src/cpps/logical/message/central_allocation/assignment_notification.h
@@ -21,17 +21,23 @@
 #include "solanet/serializer/serialize.h"
 
 namespace daisi::cpps::logical {
+
+/// @brief Notification by a central initiator that a task has been assigned to the receiving
+/// participant.
 class AssignmentNotification {
 public:
   AssignmentNotification() = default;
-  AssignmentNotification(daisi::material_flow::Task &task) : task_(task){};
+  AssignmentNotification(material_flow::Task task, std::string initiator_connection)
+      : task_(std::move(task)), initiator_connection_(std::move(initiator_connection)) {}
 
-  const daisi::material_flow::Task &getTask() const { return task_; }
+  const material_flow::Task &getTask() const { return task_; }
+  const std::string &getInitiatorConnection() const { return initiator_connection_; }
 
-  SERIALIZE(task_);
+  SERIALIZE(task_, initiator_connection_);
 
 private:
-  daisi::material_flow::Task task_;
+  material_flow::Task task_;
+  std::string initiator_connection_;
 };
 
 }  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/message/central_allocation/assignment_notification.h
+++ b/daisi/src/cpps/logical/message/central_allocation/assignment_notification.h
@@ -1,0 +1,39 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_MESSAGE_CENTRAL_ALLOCATION_ASSIGNMENT_NOTIFICATION_H_
+#define DAISI_CPPS_LOGICAL_MESSAGE_CENTRAL_ALLOCATION_ASSIGNMENT_NOTIFICATION_H_
+
+#include "material_flow/model/task.h"
+#include "solanet/serializer/serialize.h"
+
+namespace daisi::cpps::logical {
+class AssignmentNotification {
+public:
+  AssignmentNotification() = default;
+  AssignmentNotification(daisi::material_flow::Task &task) : task_(task){};
+
+  const daisi::material_flow::Task &getTask() const { return task_; }
+
+  SERIALIZE(task_);
+
+private:
+  daisi::material_flow::Task task_;
+};
+
+}  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/message/central_allocation/assignment_response.h
+++ b/daisi/src/cpps/logical/message/central_allocation/assignment_response.h
@@ -23,16 +23,18 @@
 
 namespace daisi::cpps::logical {
 
+/// @brief Response of a central participant as a reaction of a task assignment. Consists of the
+/// task_uuid, the acception / rejection, its connection string and of the new current status.
 class AssignmentResponse {
 public:
   AssignmentResponse() = default;
-  AssignmentResponse(std::string task_uuid, bool accept, Metrics metrics, util::Position position,
-                     std::string participant_connection)
+  AssignmentResponse(std::string task_uuid, bool accept, const Metrics &metrics,
+                     util::Position position, std::string participant_connection)
       : task_uuid_(std::move(task_uuid)),
         accept_(accept),
         metrics_(metrics),
         end_position_(position),
-        participant_connection_(std::move(participant_connection)){};
+        participant_connection_(std::move(participant_connection)) {}
 
   const std::string &getTaskUuid() const { return task_uuid_; }
 
@@ -45,11 +47,12 @@ public:
 private:
   std::string task_uuid_;
 
-  std::string participant_connection_;
+  bool accept_;
+
   Metrics metrics_;
   util::Position end_position_;
 
-  bool accept_;
+  std::string participant_connection_;
 };
 
 }  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/message/central_allocation/assignment_response.h
+++ b/daisi/src/cpps/logical/message/central_allocation/assignment_response.h
@@ -1,0 +1,57 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_MESSAGE_CENTRAL_ALLOCATION_ASSIGNMENT_RESPONSE_H_
+#define DAISI_CPPS_LOGICAL_MESSAGE_CENTRAL_ALLOCATION_ASSIGNMENT_RESPONSE_H_
+
+#include "cpps/amr/model/amr_static_ability.h"
+#include "cpps/logical/order_management/metrics_composition.h"
+#include "solanet/serializer/serialize.h"
+
+namespace daisi::cpps::logical {
+
+class AssignmentResponse {
+public:
+  AssignmentResponse() = default;
+  AssignmentResponse(std::string task_uuid, bool accept, Metrics metrics, util::Position position,
+                     std::string participant_connection)
+      : task_uuid_(std::move(task_uuid)),
+        accept_(accept),
+        metrics_(metrics),
+        end_position_(position),
+        participant_connection_(std::move(participant_connection)){};
+
+  const std::string &getTaskUuid() const { return task_uuid_; }
+
+  const std::string &getParticipantConnection() const { return participant_connection_; }
+
+  bool doesAccept() const { return accept_; }
+
+  SERIALIZE(task_uuid_, accept_, metrics_, end_position_, participant_connection_);
+
+private:
+  std::string task_uuid_;
+
+  std::string participant_connection_;
+  Metrics metrics_;
+  util::Position end_position_;
+
+  bool accept_;
+};
+
+}  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/message/central_allocation/status_update.h
+++ b/daisi/src/cpps/logical/message/central_allocation/status_update.h
@@ -25,25 +25,26 @@
 namespace daisi::cpps::logical {
 
 /// might need some revision / additions in the future
+// Message that consists information about a participant's status.
 class StatusUpdate {
 public:
   StatusUpdate() = default;
-  StatusUpdate(std::string participant_connection, const Metrics metrics,
-               const daisi::util::Position end_position)
+  StatusUpdate(std::string participant_connection, const Metrics &metrics,
+               const util::Position end_position)
       : participant_connection_(std::move(participant_connection)),
         metrics_(metrics),
         end_position_(end_position) {}
 
   const std::string &getParticipantConnection() const { return participant_connection_; }
   const Metrics &getMetrics() { return metrics_; }
-  const daisi::util::Position getEndPosition() { return end_position_; }
+  const util::Position getEndPosition() { return end_position_; }
 
   SERIALIZE(participant_connection_, metrics_, end_position_);
 
 private:
   std::string participant_connection_;
   Metrics metrics_;
-  daisi::util::Position end_position_;
+  util::Position end_position_;
 };
 }  // namespace daisi::cpps::logical
 

--- a/daisi/src/cpps/logical/message/central_allocation/status_update.h
+++ b/daisi/src/cpps/logical/message/central_allocation/status_update.h
@@ -1,0 +1,50 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_MESSAGE_CENTRAL_ALLOCATION_STATUS_UPDATE_H_
+#define DAISI_CPPS_LOGICAL_MESSAGE_CENTRAL_ALLOCATION_STATUS_UPDATE_H_
+
+#include "cpps/amr/model/amr_static_ability.h"
+#include "cpps/logical/order_management/metrics_composition.h"
+#include "solanet/serializer/serialize.h"
+#include "utils/structure_helpers.h"
+
+namespace daisi::cpps::logical {
+
+/// might need some revision / additions in the future
+class StatusUpdate {
+public:
+  StatusUpdate() = default;
+  StatusUpdate(std::string participant_connection, const Metrics metrics,
+               const daisi::util::Position end_position)
+      : participant_connection_(std::move(participant_connection)),
+        metrics_(metrics),
+        end_position_(end_position) {}
+
+  const std::string &getParticipantConnection() const { return participant_connection_; }
+  const Metrics &getMetrics() { return metrics_; }
+  const daisi::util::Position getEndPosition() { return end_position_; }
+
+  SERIALIZE(participant_connection_, metrics_, end_position_);
+
+private:
+  std::string participant_connection_;
+  Metrics metrics_;
+  daisi::util::Position end_position_;
+};
+}  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/message/central_allocation/status_update_request.h
+++ b/daisi/src/cpps/logical/message/central_allocation/status_update_request.h
@@ -1,0 +1,33 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_MESSAGE_CENTRAL_ALLOCATION_STATUS_UPDATE_REQUEST_H_
+#define DAISI_CPPS_LOGICAL_MESSAGE_CENTRAL_ALLOCATION_STATUS_UPDATE_REQUEST_H_
+
+#include "solanet/serializer/serialize.h"
+
+namespace daisi::cpps::logical {
+
+/// might need some revision / additions in the future
+class StatusUpdateRequest {
+public:
+  StatusUpdateRequest() = default;
+
+  SERIALIZE();
+};
+}  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/message/central_allocation/status_update_request.h
+++ b/daisi/src/cpps/logical/message/central_allocation/status_update_request.h
@@ -22,11 +22,19 @@
 namespace daisi::cpps::logical {
 
 /// might need some revision / additions in the future
+// A request to the receiving central participant to send its current status.
 class StatusUpdateRequest {
 public:
   StatusUpdateRequest() = default;
+  explicit StatusUpdateRequest(std::string initiator_connection)
+      : initiator_connection_(std::move(initiator_connection)) {}
 
-  SERIALIZE();
+  const std::string &getInitiatorConnection() const { return initiator_connection_; }
+
+  SERIALIZE(initiator_connection_);
+
+private:
+  std::string initiator_connection_;
 };
 }  // namespace daisi::cpps::logical
 

--- a/daisi/src/cpps/logical/message/serializer.h
+++ b/daisi/src/cpps/logical/message/serializer.h
@@ -25,11 +25,16 @@
 #include "auction_based/iteration_notification.h"
 #include "auction_based/winner_notification.h"
 #include "auction_based/winner_response.h"
+#include "central_allocation/assignment_notification.h"
+#include "central_allocation/assignment_response.h"
+#include "central_allocation/status_update.h"
+#include "central_allocation/status_update_request.h"
 
 namespace daisi::cpps::logical {
 
 using Message = std::variant<CallForProposal, BidSubmission, IterationNotification,
-                             WinnerNotification, WinnerResponse>;
+                             WinnerNotification, WinnerResponse, AssignmentNotification,
+                             AssignmentResponse, StatusUpdate, StatusUpdateRequest>;
 
 std::string serialize(const Message &msg);
 

--- a/daisi/src/cpps/logical/order_management/simple_order_management.cpp
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.cpp
@@ -26,6 +26,13 @@ SimpleOrderManagement::SimpleOrderManagement(const AmrDescription &amr_descripti
 
 Metrics SimpleOrderManagement::getFinalMetrics() const { return final_metrics_; }
 
+daisi::util::Position SimpleOrderManagement::getExpectedEndPosition() const {
+  if (!expected_end_position_.has_value()) {
+    throw std::logic_error("there must exist at least a position for the amr to start from");
+  }
+  return expected_end_position_.value();
+}
+
 void SimpleOrderManagement::setCurrentTime(const daisi::util::Duration &now) {
   if (now < time_now_) {
     throw std::invalid_argument("new time must be later than current time");
@@ -129,10 +136,7 @@ void SimpleOrderManagement::insertOrderPropertiesIntoMetrics(
   }
   daisi::util::Position previous_position;
   if (!previous_location.has_value()) {
-    if (!expected_end_position_.has_value()) {
-      throw std::logic_error("there must exist a location for the amr to start from");
-    }
-    previous_position = expected_end_position_.value();
+    previous_position = getExpectedEndPosition();
   } else {
     previous_position = previous_location.value().getPosition();
   }

--- a/daisi/src/cpps/logical/order_management/simple_order_management.cpp
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.cpp
@@ -28,14 +28,14 @@ Metrics SimpleOrderManagement::getFinalMetrics() const { return final_metrics_; 
 
 daisi::util::Position SimpleOrderManagement::getExpectedEndPosition() const {
   if (!expected_end_position_.has_value()) {
-    throw std::logic_error("there must exist at least a position for the amr to start from");
+    throw std::logic_error("There must exist at least a position for the AMR to start from.");
   }
   return expected_end_position_.value();
 }
 
 void SimpleOrderManagement::setCurrentTime(const daisi::util::Duration &now) {
   if (now < time_now_) {
-    throw std::invalid_argument("new time must be later than current time");
+    throw std::invalid_argument("New time must be later than current time.");
   }
   time_now_ = now;
 }
@@ -44,7 +44,7 @@ bool SimpleOrderManagement::hasTasks() const { return active_task_.has_value(); 
 
 Task SimpleOrderManagement::getCurrentTask() const {
   if (!hasTasks()) {
-    throw std::logic_error("no tasks available");
+    throw std::logic_error("No tasks available!");
   }
   return active_task_.value();
 }
@@ -70,7 +70,7 @@ bool SimpleOrderManagement::addTask(const Task &task) {
   // simply add all orders in the given order
   const auto orders = task.getOrders();
   if (orders.empty()) {
-    throw std::invalid_argument("Task must have at least one order");
+    throw std::invalid_argument("Task must have at least one order.");
   }
 
   queue_.push_back(task);
@@ -88,7 +88,7 @@ bool SimpleOrderManagement::addTask(const Task &task) {
     }
   }
   if (!final_order.has_value()) {
-    throw std::logic_error("Task must contain at least one TransportOrder or MoveOrder");
+    throw std::logic_error("Task must contain at least one TransportOrder or MoveOrder.");
   }
   auto end_location = OrderManagementHelper::getEndLocationOfOrder(final_order.value());
   expected_end_position_ = end_location->getPosition();
@@ -144,7 +144,7 @@ void SimpleOrderManagement::insertOrderPropertiesIntoMetrics(
 
   if (std::holds_alternative<MoveOrder>(order)) {
     if (order_index == 0) {
-      throw std::invalid_argument("move order should not be first");
+      throw std::invalid_argument("Move order should not be first.");
     }
     metrics.empty_travel_time += AmrMobilityHelper::estimateDuration(
         daisi::util::Pose{}, funcs, amr_description_, topology_, false);
@@ -162,7 +162,7 @@ void SimpleOrderManagement::insertOrderPropertiesIntoMetrics(
     metrics.action_time += AmrMobilityHelper::estimateDuration(daisi::util::Pose{}, funcs,
                                                                amr_description_, topology_, false);
   } else {
-    throw std::invalid_argument("Order type not supported");
+    throw std::invalid_argument("Order type not supported!");
   }
 }
 

--- a/daisi/src/cpps/logical/order_management/simple_order_management.h
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.h
@@ -33,6 +33,9 @@ public:
   /// the management
   Metrics getFinalMetrics() const;
 
+  /// @brief return the end position after executing the final task in the queue
+  daisi::util::Position getExpectedEndPosition() const;
+
   /// @brief check wether the order management has a current task assigned
   bool hasTasks() const override;
 


### PR DESCRIPTION
As an introduction into centralized task assignment strategies, a simple round robin strategy is implemented. This includes two parties, the central initiator who realizes task assignment, and the participants that simply accept the assigned tasks.

# Definition of Done
- [x] Feature is implemented
- [x] No known bugs that stops the correct execution
- [x] CI / CD pipeline passed
- [X] The code guidelines were followed
- [ ] Unit and / or Integration tests for the new feature
- [ ] New feature was added to the documentation 