### PR TITLE
refactor(daisi): Simplify network initialization

### DIFF
--- a/daisi/src/cpps/amr/physical/CMakeLists.txt
+++ b/daisi/src/cpps/amr/physical/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(daisi_cpps_amr_physical_amr_physical_asset
     daisi_cpps_amr_message_amr_state
     daisi_cpps_amr_message_serializer
     daisi_cpps_packet
+    daisi_socket_manager
 )
 target_include_directories(daisi_cpps_amr_physical_amr_physical_asset
     PUBLIC

--- a/daisi/src/cpps/amr/physical/amr_physical_asset.cpp
+++ b/daisi/src/cpps/amr/physical/amr_physical_asset.cpp
@@ -22,6 +22,7 @@
 #include "ns3/mobility-module.h"
 #include "ns3/object.h"
 #include "utils/daisi_check.h"
+#include "utils/socket_manager.h"
 
 namespace daisi::cpps {
 
@@ -39,8 +40,8 @@ AmrPhysicalAsset::AmrPhysicalAsset(AmrAssetConnector connector)
       connector_(std::move(connector)) {
 }  // always initialize to kFinished since it is equivalent to having no task/being idle
 
-void AmrPhysicalAsset::init(const ns3::Ptr<ns3::Socket> &socket) {
-  socket_ = socket;
+void AmrPhysicalAsset::init() {
+  socket_ = SocketManager::get().createSocket(SocketType::kTCP, true);
   socket_->SetRecvCallback(MakeCallback(&AmrPhysicalAsset::readSocket, this));
 }
 

--- a/daisi/src/cpps/amr/physical/amr_physical_asset.h
+++ b/daisi/src/cpps/amr/physical/amr_physical_asset.h
@@ -54,7 +54,7 @@ public:
   AmrPhysicalAsset(AmrAssetConnector connector, const Topology &topology);
   explicit AmrPhysicalAsset(AmrAssetConnector connector);
 
-  void init(const ns3::Ptr<ns3::Socket> &socket);
+  void init();
 
   void connect(const ns3::InetSocketAddress &endpoint);
 

--- a/daisi/src/cpps/common/CMakeLists.txt
+++ b/daisi/src/cpps/common/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(daisi_cpps_common_cpps_application
         daisi_cpps_logical_amr_amr_logical_agent
         daisi_cpps_common_cpps_logger_ns3
         daisi_cpps_logical_material_flow_material_flow_logical_agent
+        PRIVATE
+        daisi_socket_manager
 )
 
 add_library(daisi_cpps_common_cpps_logger_ns3 STATIC)

--- a/daisi/src/cpps/common/cpps_application.h
+++ b/daisi/src/cpps/common/cpps_application.h
@@ -33,8 +33,6 @@
 
 namespace daisi::cpps {
 
-extern std::deque<ns3::Ptr<ns3::Socket>> socket_global_;
-
 struct CppsApplication final : public ns3::Application {
   static ns3::TypeId GetTypeId();
 
@@ -42,12 +40,6 @@ struct CppsApplication final : public ns3::Application {
   void start();
   void cleanup();
 
-  void generateUDPSockets();
-  ns3::Ptr<ns3::Socket> generateTCPSocket();
-  ns3::Ipv4Address local_ip_address;
-  ns3::Ipv4Address local_ip_address_tcp;
-  uint16_t listening_port;
-  uint16_t listening_port_tcp;
   std::shared_ptr<daisi::cpps::CppsLoggerNs3> logger;
   std::variant<std::monostate, std::shared_ptr<AmrPhysicalAsset>,
                std::shared_ptr<logical::MaterialFlowLogicalAgent>,

--- a/daisi/src/cpps/logical/CMakeLists.txt
+++ b/daisi/src/cpps/logical/CMakeLists.txt
@@ -17,4 +17,7 @@ target_link_libraries(daisi_cpps_logical_logical_agent
     daisi_cpps_logical_message_serializer
     daisi_cpps_common_uuid_generator
     daisi_cpps_common_cpps_logger_ns3
+    PRIVATE
+    daisi_utils
+    daisi_socket_manager
 )

--- a/daisi/src/cpps/logical/amr/amr_logical_agent.cpp
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.cpp
@@ -21,6 +21,8 @@
 #include "cpps/logical/algorithms/disposition/iterated_auction_disposition_participant.h"
 #include "cpps/logical/order_management/stn_order_management.h"
 #include "cpps/packet.h"
+#include "utils/daisi_check.h"
+#include "utils/socket_manager.h"
 #include "utils/sola_utils.h"
 
 namespace daisi::cpps::logical {
@@ -31,10 +33,10 @@ AmrLogicalAgent::AmrLogicalAgent(uint32_t device_id, const AlgorithmConfig &conf
       topology_(daisi::util::Dimensions(50, 20, 0))  // TODO placeholder
 {}
 
-void AmrLogicalAgent::init(ns3::Ptr<ns3::Socket> tcp_socket) {
+void AmrLogicalAgent::init() {
   initCommunication();
 
-  server_socket_ = tcp_socket;
+  server_socket_ = SocketManager::get().createSocket(SocketType::kTCP, true);
   server_socket_->Listen();
 
   server_socket_->SetAcceptCallback(

--- a/daisi/src/cpps/logical/amr/amr_logical_agent.h
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.h
@@ -39,11 +39,18 @@ public:
   ~AmrLogicalAgent() override = default;
 
   /// @brief Method called by the container on start. Initializing components such as Sola.
-  virtual void init(ns3::Ptr<ns3::Socket> tcp_socket);
+  virtual void init();
 
   void start() override;
 
   void notifyTaskAssigned();
+
+  /// Get address from TCP socket listening on connections from AmrPhysicalAsset
+  ns3::InetSocketAddress getServerAddress() const {
+    ns3::Address addr;
+    server_socket_->GetSockName(addr);
+    return ns3::InetSocketAddress::ConvertFrom(addr);
+  }
 
 private:
   void initAlgorithms() override;

--- a/daisi/src/manager/CMakeLists.txt
+++ b/daisi/src/manager/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(daisi_manager
     ns3::libcsma
     ns3::libinternet
     daisi_random_engine
+    daisi_socket_manager
 )
 
 target_include_directories(daisi_manager

--- a/daisi/src/manager/sola_helper.h
+++ b/daisi/src/manager/sola_helper.h
@@ -24,33 +24,12 @@
 
 namespace daisi {
 
-template <typename T> class SolaHelper {
-public:
-  SolaHelper(std::vector<ns3::Ipv4Address> local_ip_address, uint16_t listening_port) {
-    assert(!local_ip_address.empty() && local_ip_address.size() <= 2);
-    factory_.SetTypeId(T::GetTypeId());
-    setAttribute("LocalIpAddress", ns3::Ipv4AddressValue(local_ip_address[0]));
-    setAttribute("ListeningPort", ns3::UintegerValue(listening_port));
-
-    if (local_ip_address.size() == 2) {
-      setAttribute("LocalIpAddressTCP", ns3::Ipv4AddressValue(local_ip_address[1]));
-      setAttribute("ListeningPortTCP", ns3::UintegerValue(3000));
-    }
-  }
-
-  ns3::ApplicationContainer install(ns3::Ptr<ns3::Node> node) const {
-    ns3::Ptr<ns3::Application> app = factory_.Create<T>();
-    node->AddApplication(app);
-    return {app};
-  }
-
-private:
-  void setAttribute(std::string name, const ns3::AttributeValue &value) {
-    factory_.Set(name, value);
-  }
-
-  ns3::ObjectFactory factory_;
-};
+template <typename T> void installApplication(ns3::Ptr<ns3::Node> node) {
+  ns3::ObjectFactory factory;
+  factory.SetTypeId(T::GetTypeId());
+  ns3::Ptr<ns3::Application> app = factory.Create<T>();
+  node->AddApplication(app);
+}
 
 }  // namespace daisi
 #endif

--- a/daisi/src/minhton-ns3/minhton_application.cpp
+++ b/daisi/src/minhton-ns3/minhton_application.cpp
@@ -29,15 +29,7 @@ namespace daisi::minhton_ns3 {
 
 TypeId MinhtonApplication::GetTypeId() {
   static TypeId tid =
-      TypeId("MinhtonApp")
-          .SetParent<Application>()
-          .AddConstructor<MinhtonApplication>()
-          .AddAttribute("LocalIpAddress", "LocalIpAddress", Ipv4AddressValue(),
-                        MakeIpv4AddressAccessor(&MinhtonApplication::local_ip_address_),
-                        MakeIpv4AddressChecker())
-          .AddAttribute("ListeningPort", "ListeningPort", UintegerValue(0),
-                        MakeUintegerAccessor(&MinhtonApplication::listening_port_),
-                        MakeUintegerChecker<uint16_t>());
+      TypeId("MinhtonApp").SetParent<Application>().AddConstructor<MinhtonApplication>();
   return tid;
 }
 
@@ -49,9 +41,6 @@ void MinhtonApplication::DoDispose() {
 }
 
 void MinhtonApplication::StartApplication() {
-  SolaNetworkUtils::get().registerNode(local_ip_address_, GetNode(), listening_port_);
-  SolaNetworkUtils::get().createSockets(getIpv4AddressString(local_ip_address_));
-
   logger_ = daisi::global_logger_manager->createMinhtonLogger(GetNode()->GetId());
 }
 

--- a/daisi/src/minhton-ns3/minhton_application.h
+++ b/daisi/src/minhton-ns3/minhton_application.h
@@ -48,10 +48,6 @@ private:
 
   ns3::Ptr<MinhtonNodeNs3> minhton_node_;
 
-  ns3::Ipv4Address local_ip_address_;
-
-  uint16_t listening_port_ = 0;
-
   std::shared_ptr<minhton::MinhtonLoggerNs3> logger_;
 };
 }  // namespace daisi::minhton_ns3

--- a/daisi/src/minhton-ns3/minhton_manager.cpp
+++ b/daisi/src/minhton-ns3/minhton_manager.cpp
@@ -70,7 +70,8 @@ void MinhtonManager::setupNodeConfigurations() {
     node_config.setTimeoutLengthsContainer(timeout_lengths_container);
 
     // Init after starting simulation
-    ns3::Simulator::Schedule(ns3::MilliSeconds(1), &MinhtonManager::initNode, this, i, node_config);
+    ns3::Simulator::ScheduleWithContext(node_container_.Get(i)->GetId(), ns3::MilliSeconds(1),
+                                        &MinhtonManager::initNode, this, i, node_config);
   }
 }
 

--- a/daisi/src/natter-ns3/natter_application.h
+++ b/daisi/src/natter-ns3/natter_application.h
@@ -64,10 +64,6 @@ private:
 
   ns3::Ptr<ns3::Socket> socket_;
 
-  ns3::Ipv4Address local_ip_address_;
-
-  uint16_t listening_port_ = 0;
-
   std::pair<uint32_t, uint32_t> level_number_;
 
   NatterMode mode_ = NatterMode::kNone;

--- a/daisi/src/natter-ns3/natter_node_ns3.h
+++ b/daisi/src/natter-ns3/natter_node_ns3.h
@@ -48,6 +48,11 @@ public:
                       uint32_t own_fanout);
   void unsubscribeTopic(const std::string &topic);
 
+  natter::NetworkInfoIPv4 getNetworkInfo() const {
+    if (!natter_minhcast_) throw std::runtime_error("natter not initialized");
+    return natter_minhcast_->getNetworkInfo();
+  }
+
 private:
   std::unique_ptr<natter::minhcast::NatterMinhcast> natter_minhcast_;
   std::shared_ptr<natter::logging::NatterLoggerNs3> logger_;

--- a/daisi/src/sola-ns3/sola_application.cpp
+++ b/daisi/src/sola-ns3/sola_application.cpp
@@ -57,9 +57,6 @@ std::string SolaApplication::getIP() const {
 }
 
 void SolaApplication::startSOLA() {
-  SolaNetworkUtils::get().registerNode(local_ip_address_, GetNode(), listening_port_);
-  SolaNetworkUtils::get().createSockets(getIpv4AddressString(local_ip_address_), 3);
-
   thread_local static uint32_t number_created = 0;
 
   const std::string config_file =

--- a/daisi/src/sola-ns3/sola_manager_scheduler.cpp
+++ b/daisi/src/sola-ns3/sola_manager_scheduler.cpp
@@ -25,7 +25,9 @@ void SolaManager::scheduleSOLAStart(scenario_it it, uint64_t &current_time) {
   assert(nodes == "all");
 
   for (uint32_t i = 0; i < number_nodes_; i++) {
-    ns3::Simulator::Schedule(ns3::MilliSeconds(current_time), &SolaManager::startSOLA, this, i);
+    ns3::Simulator::ScheduleWithContext(node_container_.Get(i)->GetId(),
+                                        ns3::MilliSeconds(current_time), &SolaManager::startSOLA,
+                                        this, i);
     current_time += delay;
   }
   current_time -= delay;  // No delay at end (should be default delay)
@@ -39,8 +41,9 @@ void SolaManager::scheduleSubscribeTopic(SolaManager::scenario_it it, uint64_t &
   assert(nodes == "all");
 
   for (uint32_t i = 0; i < number_nodes_; i++) {
-    ns3::Simulator::Schedule(ns3::MilliSeconds(current_time), &SolaManager::subscribeTopic, this,
-                             topic, i);
+    ns3::Simulator::ScheduleWithContext(node_container_.Get(i)->GetId(),
+                                        ns3::MilliSeconds(current_time),
+                                        &SolaManager::subscribeTopic, this, topic, i);
     current_time += delay;
   }
   current_time -= delay;  // No delay at end (should be default delay)
@@ -57,8 +60,9 @@ void SolaManager::schedulePublish(scenario_it it, uint64_t &current_time) {
   try {
     //    uint32_t node_number = std::stoi(nodes);
     uint32_t node_number = nodes;
-    ns3::Simulator::Schedule(ns3::MilliSeconds(current_time), &SolaManager::publishTopic, this,
-                             node_number, topic, msg_size);
+    ns3::Simulator::ScheduleWithContext(node_container_.Get(node_number)->GetId(),
+                                        ns3::MilliSeconds(current_time), &SolaManager::publishTopic,
+                                        this, node_number, topic, msg_size);
   } catch (...) {
     std::cerr << "failed node conversion" << std::endl;
     throw;

--- a/daisi/src/sola-ns3/sola_ns3_wrapper.cpp
+++ b/daisi/src/sola-ns3/sola_ns3_wrapper.cpp
@@ -48,9 +48,6 @@ SOLAWrapperNs3::SOLAWrapperNs3(const sola::ManagementOverlayMinhton::Config &con
 
 void SOLAWrapperNs3::subscribeTopic(const std::string &topic) {
   if (!isSubscribed(topic)) {
-    std::string ip = getIP();
-
-    SolaNetworkUtils::get().createSockets(ip);
     logger_->logTopicEvent(topic, node_name_, true);
     const std::string postfix = "ED:" + topic;
     std::vector<sola::ManagementOverlayMinhton::Logger> logger_list{

--- a/daisi/src/solanet-ns3/CMakeLists.txt
+++ b/daisi/src/solanet-ns3/CMakeLists.txt
@@ -6,7 +6,13 @@ target_sources(NetworkUDPSim
     ns3SolaNet.cpp
 )
 
-target_link_libraries(NetworkUDPSim PRIVATE ns3::libcore daisi_utils daisi_solanet_message_ns3)
+target_link_libraries(NetworkUDPSim
+    PRIVATE
+    ns3::libcore
+    daisi_utils
+    daisi_solanet_message_ns3
+    daisi_socket_manager
+)
 target_include_directories(NetworkUDPSim
     PUBLIC
     ${SolaNet_SOURCE_DIR}/include/)

--- a/daisi/src/utils/CMakeLists.txt
+++ b/daisi/src/utils/CMakeLists.txt
@@ -40,3 +40,18 @@ target_include_directories(daisi_structure_helpers
         PUBLIC
         ${PROJECT_SOURCE_DIR}/src
 )
+
+add_library(daisi_socket_manager STATIC)
+target_sources(daisi_socket_manager
+        PRIVATE
+        socket_manager.cpp
+        socket_manager.h
+)
+target_link_libraries(daisi_socket_manager
+        PUBLIC
+        ns3::libcore
+)
+target_include_directories(daisi_socket_manager
+        PUBLIC
+        ${PROJECT_SOURCE_DIR}/src
+)

--- a/daisi/src/utils/socket_manager.cpp
+++ b/daisi/src/utils/socket_manager.cpp
@@ -1,0 +1,69 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "utils/socket_manager.h"
+
+#include "utils/daisi_check.h"
+
+namespace daisi {
+ns3::Ptr<ns3::Socket> SocketManager::createSocket(SocketType type, bool localhost) {
+  const uint32_t context = ns3::Simulator::GetContext();
+  DAISI_CHECK(context != ns3::Simulator::NO_CONTEXT, "Context not set");
+
+  static std::unordered_map<SocketType, std::string> socket_factory_map{
+      {SocketType::kUDP, "ns3::UdpSocketFactory"}, {SocketType::kTCP, "ns3::TcpSocketFactory"}};
+
+  ns3::TypeId tid = ns3::TypeId::LookupByName(socket_factory_map.at(type));
+
+  std::vector<NetworkInfo> &infos = nodes_.at(context);
+
+  // Find info with correct tag
+  auto it = std::find_if(infos.begin(), infos.end(), [localhost](const NetworkInfo &info) {
+    return info.tag == (localhost ? "localhost" : "real");
+  });
+  DAISI_CHECK(it != infos.end(), "No network info found with required tag");
+
+  NetworkInfo &info = *it;
+
+  auto socket = ns3::Socket::CreateSocket(info.node, tid);
+  ns3::InetSocketAddress local_address(info.address, info.next_free_port);
+  info.next_free_port++;
+  socket->Bind(local_address);
+
+  if (socket->GetErrno() != ns3::Socket::ERROR_NOTERROR) {
+    throw std::runtime_error("failed to open socket");
+  }
+  return socket;
+}
+
+void SocketManager::registerNode(std::vector<ns3::Ipv4Address> addresses,
+                                 const ns3::Ptr<ns3::Node> &node, uint16_t first_free_port) {
+  DAISI_CHECK(nodes_.find(node->GetId()) == nodes_.end(), "Node already registered");
+  std::vector<NetworkInfo> infos;
+  for (const auto &address : addresses) {
+    std::string tag = "real";
+    if (address.Get() == 2130706433) {  // 127.0.0.1
+      tag = "localhost";
+    }
+
+    infos.push_back({node, address, first_free_port, tag});
+  }
+  nodes_[node->GetId()] = infos;
+}
+
+void SocketManager::unregisterNode(const ns3::Ptr<ns3::Node> &node) { nodes_.erase(node->GetId()); }
+
+}  // namespace daisi

--- a/daisi/src/utils/socket_manager.h
+++ b/daisi/src/utils/socket_manager.h
@@ -1,0 +1,63 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_UTILS_SOCKET_MANAGER_H_
+#define DAISI_UTILS_SOCKET_MANAGER_H_
+
+#include <string>
+#include <vector>
+
+#include "ns3/core-module.h"
+#include "ns3/network-module.h"
+
+namespace daisi {
+
+enum class SocketType { kUDP, kTCP };
+
+class SocketManager {
+public:
+  /// Getter for singleton
+  static SocketManager &get() {
+    static SocketManager utils;
+    return utils;
+  }
+
+  ns3::Ptr<ns3::Socket> createSocket(SocketType type, bool localhost = false);
+
+  void registerNode(std::vector<ns3::Ipv4Address> addresses, const ns3::Ptr<ns3::Node> &node,
+                    uint16_t first_free_port);
+
+  // Unregister as active node
+  void unregisterNode(const ns3::Ptr<ns3::Node> &node);
+
+private:
+  SocketManager() = default;
+
+  struct NetworkInfo {
+    ns3::Ptr<ns3::Node> node;
+    ns3::Ipv4Address address;
+    uint16_t next_free_port;
+    std::string tag;
+  };
+
+  using Context = uint32_t;  // ns-3 context
+
+  std::unordered_map<Context, std::vector<NetworkInfo>> nodes_;
+};
+
+}  // namespace daisi
+
+#endif

--- a/daisi/src/utils/sola_utils.h
+++ b/daisi/src/utils/sola_utils.h
@@ -28,36 +28,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "ns3/ipv4-address.h"
-#include "ns3/node.h"
+#include "ns3/network-module.h"
 
 namespace daisi {
-
-struct NodeNetworkInfo {
-  ns3::Ptr<ns3::Node> node;
-  uint16_t next_free_port;
-};
-
-class SolaNetworkUtils {
-public:
-  static SolaNetworkUtils &get() {
-    static SolaNetworkUtils utils;
-    return utils;
-  }
-
-  void createSockets(const std::string &ip, uint32_t amount = 1);
-
-  void registerNode(ns3::Ipv4Address address, const ns3::Ptr<ns3::Node> &node,
-                    uint16_t next_free_port);
-
-  // Unregister as active node
-  void unregisterNode(ns3::Ipv4Address address);
-
-private:
-  SolaNetworkUtils() = default;
-
-  std::unordered_map<std::string, NodeNetworkInfo> nodes_;
-};
 
 std::string getScenariofilePath(std::string scenariofile_name);
 int getTestFile(std::string &scenariofile_name, std::string &scenariofile_string,
@@ -72,6 +45,9 @@ std::string generateDBNameWithMinhtonInfo(const std::string &app_name, uint16_t 
 
 std::string generateDBName(const std::string &app_name);
 std::string generateDBName(const std::string &app_name, const std::string &identification_string);
+
+std::vector<ns3::Ipv4Address> getAddressesForNode(const ns3::NodeContainer &container,
+                                                  uint32_t node_container_idx);
 
 }  // namespace daisi
 #endif


### PR DESCRIPTION
Previously we used a global ``std::deque`` to pass ns-3 sockets to SolaNetNs3. Hence it was required to insert sockets into this queue before starting the application or subscribing to new topics (as new topic trees are created). This procedure is error-prone.

This PR utilizes the ns-3 context to identify on which node the current event/code is executed. With this information SolaNetNs3 can call ``SocketManager::createSocket(...)`` itself when required. This also helps with the initialization of TCP sockets required for the Logical AMR <-> Physical AMR communication. 

:warning: CPPS database outputs after this commit are not 100% equal to outputs before this commit. Thats because  the call to ``CppsManager::initMF(..)`` is now scheduled and not called directly as before [1]. This results in different application UUIDs for some applications and little shifts in the networking timestamps/order. But overall this shouldn't have any side-effects on the correctness.

[1] https://github.com/ltoenning/sola/blob/48a5b90295d833db8bc766c814c3a88c06066a9e/daisi/src/cpps/common/cpps_manager.cpp#L455-L456 i