### PR TITLE
Create MINHTON topic tree logger through function in config

### DIFF
--- a/daisi/src/cpps/logical/CMakeLists.txt
+++ b/daisi/src/cpps/logical/CMakeLists.txt
@@ -21,4 +21,5 @@ target_link_libraries(daisi_cpps_logical_logical_agent
     daisi_socket_manager
     solanet_uuid
     solanet_uuid_generator_sim
+    sola_config_helper_ns3
 )

--- a/daisi/src/cpps/logical/logical_agent.cpp
+++ b/daisi/src/cpps/logical/logical_agent.cpp
@@ -54,8 +54,8 @@ void LogicalAgent::initCommunication() {
     this->topicMessageReceiveFunction(msg);
   };
 
-  sola_ = std::make_unique<sola_ns3::SOLAWrapperNs3>(
-      config_mo, config_ed, message_recv_fct, topic_message_recv_fct, logger_, uuid_, device_id_);
+  sola_ = std::make_unique<sola_ns3::SOLAWrapperNs3>(config_mo, config_ed, message_recv_fct,
+                                                     topic_message_recv_fct, logger_, uuid_);
 }
 
 void LogicalAgent::processMessage(const Message &msg) {

--- a/daisi/src/cpps/logical/logical_agent.cpp
+++ b/daisi/src/cpps/logical/logical_agent.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 
 #include "minhton/utils/config_reader.h"
+#include "sola-ns3/config_helper_ns3.h"
 #include "solanet/uuid.h"
 #include "solanet/uuid_generator.h"
 
@@ -36,13 +37,14 @@ void LogicalAgent::initCommunication() {
       first_node_ ? "configurations/root.yml" : "configurations/join.yml";
 
   sola::ManagementOverlayMinhton::Config config_mo = minhton::config::readConfig(config_file);
+  sola_ns3::configureLogger(config_mo);
 
   if (!first_node_) {
     sola_ns3::SOLAWrapperNs3::setJoinIp(config_mo);
   }
 
-  // Nothing to configure (yet)
   sola::EventDisseminationMinhcast::Config config_ed;
+  sola_ns3::configureLogger(config_ed);
 
   uuid_ = solanet::uuidToString(solanet::generateUUID());
   logger_->setApplicationUUID(uuid_);

--- a/daisi/src/sola-ns3/CMakeLists.txt
+++ b/daisi/src/sola-ns3/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(daisi_sola_application
         PRIVATE
         daisi_utils
         minhton_utils_config_reader
+        sola_config_helper_ns3
 )
 
 add_library(daisi_sola_logger_ns3 STATIC)
@@ -97,3 +98,12 @@ target_link_libraries(ManagementOverlayMINHTONSim
 target_include_directories(ManagementOverlayMINHTONSim
         PUBLIC
         ${SOLA_SOURCE_DIR}/include)
+
+add_library(sola_config_helper_ns3 INTERFACE config_helper_ns3.h)
+target_link_libraries(sola_config_helper_ns3 INTERFACE
+        ManagementOverlayMINHTONSim
+        EventDisseminationMinhcastSim
+        daisi_logger_manager
+        ns3::libcore
+        daisi_utils
+)

--- a/daisi/src/sola-ns3/config_helper_ns3.h
+++ b/daisi/src/sola-ns3/config_helper_ns3.h
@@ -1,0 +1,49 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_SOLA_NS3_CONFIG_HELPER_NS3_H_
+#define DAISI_SOLA_NS3_CONFIG_HELPER_NS3_H_
+
+#include "SOLA/event_dissemination_minhcast.h"
+#include "SOLA/management_overlay_minhton.h"
+#include "logging/logger_manager.h"
+#include "ns3/simulator.h"
+#include "utils/daisi_check.h"
+
+namespace daisi::sola_ns3 {
+
+inline void configureLogger(sola::ManagementOverlayMinhton::Config &config) {
+  const uint64_t device_id = ns3::Simulator::GetContext();
+  DAISI_CHECK(device_id != ns3::Simulator::NO_CONTEXT, "Context not set");
+
+  config.setLogger(std::vector<sola::ManagementOverlayMinhton::Logger>{
+      daisi::global_logger_manager->createMinhtonLogger(device_id, "MO")});
+}
+
+inline void configureLogger(sola::EventDisseminationMinhcast::Config &config) {
+  const uint64_t device_id = ns3::Simulator::GetContext();
+  DAISI_CHECK(device_id != ns3::Simulator::NO_CONTEXT, "Context not set");
+
+  config.logger = std::vector<sola::EventDisseminationMinhcast::Logger>{
+      daisi::global_logger_manager->createNatterLogger(device_id)};
+  config.topic_tree_logger_create_fct = [device_id](const std::string &topic) {
+    const std::string postfix = "ED:" + topic;
+    return daisi::global_logger_manager->createMinhtonLogger(device_id, postfix);
+  };
+}
+
+}  // namespace daisi::sola_ns3
+#endif

--- a/daisi/src/sola-ns3/sola_application.cpp
+++ b/daisi/src/sola-ns3/sola_application.cpp
@@ -17,6 +17,7 @@
 #include "sola_application.h"
 
 #include "minhton/utils/config_reader.h"
+#include "sola-ns3/config_helper_ns3.h"
 #include "utils/sola_utils.h"
 
 using namespace ns3;
@@ -63,9 +64,11 @@ void SolaApplication::startSOLA() {
       (number_created == 0) ? "configurations/root.yml" : "configurations/join.yml";
 
   sola::ManagementOverlayMinhton::Config config_mo = minhton::config::readConfig(config_file);
+  sola_ns3::configureLogger(config_mo);
 
-  // Nothing to configure (yet)
   sola::EventDisseminationMinhcast::Config config_ed;
+  sola_ns3::configureLogger(config_ed);
+
   number_created++;
 
   auto single_receive = [](const sola::Message &msg) {

--- a/daisi/src/sola-ns3/sola_application.cpp
+++ b/daisi/src/sola-ns3/sola_application.cpp
@@ -81,9 +81,9 @@ void SolaApplication::startSOLA() {
   };
 
   auto logger = daisi::global_logger_manager->createSolaLogger(GetNode()->GetId());
-  sola_ = std::make_unique<sola_ns3::SOLAWrapperNs3>(
-      config_mo, config_ed, single_receive, topic_receive, logger, "",
-      GetNode()->GetId());  // Already joining overlay network
+  sola_ = std::make_unique<sola_ns3::SOLAWrapperNs3>(config_mo, config_ed, single_receive,
+                                                     topic_receive, logger,
+                                                     "");  // Already joining overlay network
 }
 
 void SolaApplication::subscribeTopic(const std::string &topic) { sola_->subscribeTopic(topic); }

--- a/daisi/src/sola-ns3/sola_ns3_wrapper.cpp
+++ b/daisi/src/sola-ns3/sola_ns3_wrapper.cpp
@@ -20,28 +20,13 @@
 
 namespace daisi::sola_ns3 {
 
-sola::ManagementOverlayMinhton::Config addLogger(sola::ManagementOverlayMinhton::Config config,
-                                                 uint32_t device_id) {
-  config.setLogger(std::vector<sola::ManagementOverlayMinhton::Logger>{
-      daisi::global_logger_manager->createMinhtonLogger(device_id, "MO")});
-  return config;
-}
-
-sola::EventDisseminationMinhcast::Config addLogger(sola::EventDisseminationMinhcast::Config config,
-                                                   uint32_t device_id) {
-  config.logger = std::vector<sola::EventDisseminationMinhcast::Logger>{
-      daisi::global_logger_manager->createNatterLogger(device_id)};
-  return config;
-}
-
 SOLAWrapperNs3::SOLAWrapperNs3(const sola::ManagementOverlayMinhton::Config &config_mo,
                                const sola::EventDisseminationMinhcast::Config &config_ed,
                                sola::MessageReceiveFct receive_fct,
                                sola::TopicMessageReceiveFct topic_recv,
                                std::shared_ptr<daisi::cpps::CppsLoggerNs3> logger,
                                std::string node_name, uint32_t device_id)
-    : SOLA(addLogger(config_mo, device_id), addLogger(config_ed, device_id), receive_fct,
-           topic_recv),
+    : SOLA(config_mo, config_ed, receive_fct, topic_recv),
       device_id_(device_id),
       logger_(std::move(logger)),
       node_name_(std::move(node_name)) {}
@@ -49,10 +34,7 @@ SOLAWrapperNs3::SOLAWrapperNs3(const sola::ManagementOverlayMinhton::Config &con
 void SOLAWrapperNs3::subscribeTopic(const std::string &topic) {
   if (!isSubscribed(topic)) {
     logger_->logTopicEvent(topic, node_name_, true);
-    const std::string postfix = "ED:" + topic;
-    std::vector<sola::ManagementOverlayMinhton::Logger> logger_list{
-        daisi::global_logger_manager->createMinhtonLogger(device_id_, postfix)};
-    SOLA::subscribeTopic(topic, logger_list);
+    SOLA::subscribeTopic(topic);
 
     subscribed_topics_.push_back(topic);
   }

--- a/daisi/src/sola-ns3/sola_ns3_wrapper.cpp
+++ b/daisi/src/sola-ns3/sola_ns3_wrapper.cpp
@@ -25,9 +25,8 @@ SOLAWrapperNs3::SOLAWrapperNs3(const sola::ManagementOverlayMinhton::Config &con
                                sola::MessageReceiveFct receive_fct,
                                sola::TopicMessageReceiveFct topic_recv,
                                std::shared_ptr<daisi::cpps::CppsLoggerNs3> logger,
-                               std::string node_name, uint32_t device_id)
+                               std::string node_name)
     : SOLA(config_mo, config_ed, receive_fct, topic_recv),
-      device_id_(device_id),
       logger_(std::move(logger)),
       node_name_(std::move(node_name)) {}
 

--- a/daisi/src/sola-ns3/sola_ns3_wrapper.h
+++ b/daisi/src/sola-ns3/sola_ns3_wrapper.h
@@ -33,8 +33,7 @@ public:
   SOLAWrapperNs3(const sola::ManagementOverlayMinhton::Config &config_mo,
                  const sola::EventDisseminationMinhcast::Config &config_ed,
                  sola::MessageReceiveFct receive_fct, sola::TopicMessageReceiveFct topic_recv,
-                 std::shared_ptr<daisi::cpps::CppsLoggerNs3> logger, std::string node_name_,
-                 uint32_t device_id);
+                 std::shared_ptr<daisi::cpps::CppsLoggerNs3> logger, std::string node_name_);
 
   void subscribeTopic(const std::string &topic);
   void unsubscribeTopic(const std::string &topic);
@@ -54,7 +53,6 @@ public:
   }
 
 private:
-  const uint32_t device_id_ = 0;
   std::shared_ptr<daisi::cpps::CppsLoggerNs3> logger_;
   std::string node_name_;
 

--- a/sola/include/SOLA/event_dissemination_minhcast.h
+++ b/sola/include/SOLA/event_dissemination_minhcast.h
@@ -33,9 +33,13 @@ namespace sola {
 
 struct EventDisseminationMinhcastConfig {
   std::vector<natter::logging::LoggerPtr> logger;
+
+  /// Function that is called to instantiate a MINHTON logger for a topic tree.
+  /// The topic name is passed into this function.
+  std::function<minhton::Logger::LoggerPtr(std::string)> topic_tree_logger_create_fct;
 };
 
-class EventDisseminationMinhcast final : public EventDissemination<minhton::Logger::LoggerPtr> {
+class EventDisseminationMinhcast final : public EventDissemination {
 public:
   using Config = EventDisseminationMinhcastConfig;
   using Logger = natter::logging::LoggerPtr;
@@ -44,7 +48,7 @@ public:
                              std::string ip, const Config &config);
   ~EventDisseminationMinhcast() override = default;
   void publish(const std::string &topic, const std::string &message) final;
-  void subscribe(const std::string &topic, std::vector<minhton::Logger::LoggerPtr> logger) final;
+  void subscribe(const std::string &topic) final;
   void unsubscribe(const std::string &topic) final;
 
   void stop() final;
@@ -58,6 +62,8 @@ private:
   // Implementation in event_dissemination_minhcast_impl.cpp
   void getResult(const std::string &topic, const std::function<void()> &on_result);
   void checkTopicJoin(const std::string &topic, bool should_exist);
+
+  const Config config_;
 
   std::unique_ptr<natter::minhcast::NatterMinhcast> minhcast_;
 

--- a/sola/include/SOLA/sola.h
+++ b/sola/include/SOLA/sola.h
@@ -28,8 +28,7 @@ namespace sola {
 
 template <typename StorageT, typename EventDisseminationT> class SOLA {
   static_assert(std::is_base_of<Storage, StorageT>());
-  static_assert(
-      std::is_base_of<EventDissemination<typename StorageT::Logger>, EventDisseminationT>());
+  static_assert(std::is_base_of<EventDissemination, EventDisseminationT>());
 
 public:
   /*! \brief Starts the SOLA instance
@@ -86,10 +85,7 @@ public:
   }
 
   // event dissemination
-  void subscribeTopic(const std::string &topic,
-                      std::vector<typename StorageT::Logger> logger = {}) {
-    ed_->subscribe(topic, logger);
-  }
+  void subscribeTopic(const std::string &topic) { ed_->subscribe(topic); }
   void unsubscribeTopic(const std::string &topic) { ed_->unsubscribe(topic); }
   void publishMessage(const std::string &topic, const std::string &message) {
     ed_->publish(topic, message);

--- a/sola/src/event_dissemination/event_dissemination.h
+++ b/sola/src/event_dissemination/event_dissemination.h
@@ -11,11 +11,11 @@
 #include <vector>
 
 namespace sola {
-template <typename LoggerT> class EventDissemination {
+class EventDissemination {
 public:
   virtual ~EventDissemination() = default;
   virtual void publish(const std::string &topic, const std::string &message) = 0;
-  virtual void subscribe(const std::string &topic, std::vector<LoggerT> logger) = 0;
+  virtual void subscribe(const std::string &topic) = 0;
   virtual void unsubscribe(const std::string &topic) = 0;
 
   virtual void stop() = 0;


### PR DESCRIPTION
This PR simplifies the creation of MINHTON topic tree loggers by not requiring  to pass a logger vector every time when calling ``subscribeTopic``.  A ``std::function`` can be passed in the initial EventDissemination config that is used to create the loggers.

Further, this PR moves the logic to create the ns-3 MINHTON logger from the ns-3 SOLA wrapper into the application, or more explicitly helper functions. The helper functions can later be expanded to create non-simulation loggers as well.
This is one step to slowly clean up up the ns-3 SOLA wrapper and to eventually remove this additional abstraction class entirely.