### PR TITLE
Log correct address of PhysicalAMR from LogicalAMR

### DIFF
--- a/daisi/src/cpps/logical/amr/amr_logical_agent.cpp
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.cpp
@@ -190,6 +190,8 @@ void AmrLogicalAgent::newConnectionCreated(ns3::Ptr<ns3::Socket> socket, const n
   physical_socket_ = socket;
   physical_socket_->SetRecvCallback(MakeCallback(&AmrLogicalAgent::readFromPhysicalSocket, this));
 
+  physical_address_ = addr;
+
   logAmrInfos();
 }
 
@@ -219,10 +221,8 @@ void AmrLogicalAgent::logAmrInfos() {
   // network
 
   // retrieve physical info
-  ns3::Address physical_address;
-  physical_socket_->GetSockName(physical_address);
-
-  ns3::InetSocketAddress i_physical_address = ns3::InetSocketAddress::ConvertFrom(physical_address);
+  ns3::InetSocketAddress i_physical_address =
+      ns3::InetSocketAddress::ConvertFrom(physical_address_);
   std::string physical_asset_ip = daisi::getIpv4AddressString(i_physical_address.GetIpv4());
   uint16_t physical_asset_port = i_physical_address.GetPort();
 

--- a/daisi/src/cpps/logical/amr/amr_logical_agent.h
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.h
@@ -106,6 +106,9 @@ private:
   /// This socket is used to communicate with the physical, for both sending and receiving messages.
   ns3::Ptr<ns3::Socket> physical_socket_;
 
+  /// @brief The address of the AmrPhysicalAsset after it connected to AmrLogicalAgent.
+  ns3::Address physical_address_;
+
   std::shared_ptr<OrderManagement> order_management_;
 };
 }  // namespace daisi::cpps::logical

--- a/daisi/src/solanet-ns3/ns3SolaNet.cpp
+++ b/daisi/src/solanet-ns3/ns3SolaNet.cpp
@@ -142,7 +142,7 @@ std::string Network::Impl::getIP() const { return ip_; }
 uint16_t Network::Impl::getPort() const { return port_; }
 
 ////////////////////////////////////
-////// PIMP IMPLEMENTATION /////////
+////// PIMPL IMPLEMENTATION ////////
 ////////////////////////////////////
 
 Network::Network(const std::function<void(const Message &)> &callback)


### PR DESCRIPTION
The address of the physical AMR is logged from the logical AMR. But ``GetSockName()`` only returns the local address of the socket. The "connection originators" address is passed with ``newConnectionCreated``.
See https://www.nsnam.org/docs/release/3.19/doxygen/classns3_1_1_socket.html#a408532e435c63166e6ccc337c0cea871