### PR TITLE
Sync order states from logical AMR agent to material flow agent

### DIFF
--- a/daisi/src/cpps/logical/algorithms/CMakeLists.txt
+++ b/daisi/src/cpps/logical/algorithms/CMakeLists.txt
@@ -26,4 +26,5 @@ target_link_libraries(daisi_cpps_logical_algorithms_algorithm_interface
     daisi_cpps_logical_message_central_allocation_assignment_response
     daisi_cpps_logical_message_central_allocation_status_update
     daisi_cpps_logical_message_central_allocation_status_update_request
+    daisi_cpps_logical_message_material_flow_update
 )

--- a/daisi/src/cpps/logical/algorithms/algorithm_interface.h
+++ b/daisi/src/cpps/logical/algorithms/algorithm_interface.h
@@ -29,6 +29,7 @@
 #include "cpps/logical/message/central_allocation/assignment_response.h"
 #include "cpps/logical/message/central_allocation/status_update.h"
 #include "cpps/logical/message/central_allocation/status_update_request.h"
+#include "cpps/logical/message/material_flow_update.h"
 #include "cpps/logical/message/serializer.h"
 #include "sola-ns3/sola_ns3_wrapper.h"
 
@@ -57,6 +58,7 @@ public:
   REGISTER_LOGICAL_MESSAGE(AssignmentResponse);
   REGISTER_LOGICAL_MESSAGE(StatusUpdate);
   REGISTER_LOGICAL_MESSAGE(StatusUpdateRequest);
+  REGISTER_LOGICAL_MESSAGE(MaterialFlowUpdate);  // TODO Ref #79
 
 protected:
   std::shared_ptr<sola_ns3::SOLAWrapperNs3> sola_;

--- a/daisi/src/cpps/logical/algorithms/disposition/iterated_auction_disposition_initiator.cpp
+++ b/daisi/src/cpps/logical/algorithms/disposition/iterated_auction_disposition_initiator.cpp
@@ -39,7 +39,8 @@ void IteratedAuctionDispositionInitiator::addMaterialFlow(
                              "is not implemented yet.");
   }
 
-  layered_precedence_graph_ = std::make_shared<LayeredPrecedenceGraph>(scheduler);
+  layered_precedence_graph_ =
+      std::make_shared<LayeredPrecedenceGraph>(scheduler, sola_->getConectionString());
   auction_initiator_state_ = std::make_unique<AuctionInitiatorState>(layered_precedence_graph_);
 
   auto sim_time = (double)ns3::Simulator::Now().GetMilliSeconds();

--- a/daisi/src/cpps/logical/algorithms/disposition/layered_precedence_graph.cpp
+++ b/daisi/src/cpps/logical/algorithms/disposition/layered_precedence_graph.cpp
@@ -21,7 +21,8 @@
 namespace daisi::cpps::logical {
 
 LayeredPrecedenceGraph::LayeredPrecedenceGraph(
-    std::shared_ptr<daisi::material_flow::MFDLScheduler> scheduler) {
+    std::shared_ptr<daisi::material_flow::MFDLScheduler> scheduler,
+    const std::string &connection_string) {
   // TODO transform scheduler content to vertices and edges
 
   // hard coded test tasks
@@ -31,21 +32,21 @@ LayeredPrecedenceGraph::LayeredPrecedenceGraph(
     material_flow::TransportOrderStep delivery1(
         "tos12", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
     material_flow::TransportOrder to1({pickup1}, delivery1);
-    material_flow::Task task1("task1", {to1}, {});
+    material_flow::Task task1("task1", connection_string, {to1}, {});
 
     material_flow::TransportOrderStep pickup2(
         "tos21", {}, material_flow::Location("0x0", "type", util::Position(20, 10)));
     material_flow::TransportOrderStep delivery2(
         "tos22", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
     material_flow::TransportOrder to2({pickup2}, delivery2);
-    material_flow::Task task2("task2", {to2}, {});
+    material_flow::Task task2("task2", connection_string, {to2}, {});
 
     material_flow::TransportOrderStep pickup3(
         "tos31", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
     material_flow::TransportOrderStep delivery3(
         "tos32", {}, material_flow::Location("0x0", "type", util::Position(5, 5)));
     material_flow::TransportOrder to3({pickup3}, delivery3);
-    material_flow::Task task3("task3", {to3}, {});
+    material_flow::Task task3("task3", connection_string, {to3}, {});
 
     amr::AmrStaticAbility ability1(amr::LoadCarrier(amr::LoadCarrier::Types::kPackage), 20);
     amr::AmrStaticAbility ability2(amr::LoadCarrier(amr::LoadCarrier::Types::kEuroBox), 20);

--- a/daisi/src/cpps/logical/algorithms/disposition/layered_precedence_graph.h
+++ b/daisi/src/cpps/logical/algorithms/disposition/layered_precedence_graph.h
@@ -39,7 +39,8 @@ namespace daisi::cpps::logical {
 /// autonomous agents & multiagent systems. 2016.
 class LayeredPrecedenceGraph : private datastructure::DirectedGraph<LPCVertex, std::monostate> {
 public:
-  explicit LayeredPrecedenceGraph(std::shared_ptr<material_flow::MFDLScheduler> scheduler);
+  explicit LayeredPrecedenceGraph(std::shared_ptr<material_flow::MFDLScheduler> scheduler,
+                                  const std::string &connection_string);
 
   ~LayeredPrecedenceGraph() = default;
 

--- a/daisi/src/cpps/logical/algorithms/disposition/round_robin_initiator.cpp
+++ b/daisi/src/cpps/logical/algorithms/disposition/round_robin_initiator.cpp
@@ -58,6 +58,7 @@ void RoundRobinInitiator::logMaterialFlowContent(const std::string &material_flo
 
 void RoundRobinInitiator::distributeMFTasks(uint32_t index, bool previously_allocated) {
   // TODO: filter the wanted information out from the MFDLScheduler
+  const std::string connection_string = sola_->getConectionString();
 
   // hardcoded tasks for testing
   material_flow::TransportOrderStep pickup1(
@@ -65,37 +66,37 @@ void RoundRobinInitiator::distributeMFTasks(uint32_t index, bool previously_allo
   material_flow::TransportOrderStep delivery1(
       "tos12", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
   material_flow::TransportOrder to1({pickup1}, delivery1);
-  material_flow::Task task1("task1", {to1}, {});
+  material_flow::Task task1("task1", connection_string, {to1}, {});
 
   material_flow::TransportOrderStep pickup2(
       "tos21", {}, material_flow::Location("0x0", "type", util::Position(20, 10)));
   material_flow::TransportOrderStep delivery2(
       "tos22", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
   material_flow::TransportOrder to2({pickup2}, delivery2);
-  material_flow::Task task2("task2", {to2}, {});
+  material_flow::Task task2("task2", connection_string, {to2}, {});
 
   material_flow::TransportOrderStep pickup3(
       "tos31", {}, material_flow::Location("0x0", "type", util::Position(10, 20)));
   material_flow::TransportOrderStep delivery3(
       "tos32", {}, material_flow::Location("0x0", "type", util::Position(5, 5)));
   material_flow::TransportOrder to3({pickup3}, delivery3);
-  material_flow::Task task3("task3", {to3}, {});
+  material_flow::Task task3("task3", connection_string, {to3}, {});
 
   material_flow::TransportOrderStep pickup4(
       "tos41", {}, material_flow::Location("0x0", "type", util::Position(0, 10)));
   material_flow::TransportOrderStep delivery4(
       "tos42", {}, material_flow::Location("0x0", "type", util::Position(15, 15)));
   material_flow::TransportOrder to4({pickup4}, delivery4);
-  material_flow::Task task4("task4", {to4}, {});
+  material_flow::Task task4("task4", connection_string, {to4}, {});
 
   material_flow::TransportOrder to5({pickup2}, delivery4);
-  material_flow::Task task5("task5", {to5}, {});
+  material_flow::Task task5("task5", connection_string, {to5}, {});
 
   material_flow::TransportOrder to6({pickup1}, delivery1);
-  material_flow::Task task6("task6", {to6}, {});
+  material_flow::Task task6("task6", connection_string, {to6}, {});
 
   material_flow::TransportOrder to7({pickup3}, delivery2);
-  material_flow::Task task7("task7", {to7}, {});
+  material_flow::Task task7("task7", connection_string, {to7}, {});
 
   amr::AmrStaticAbility ability1(amr::LoadCarrier(amr::LoadCarrier::Types::kPackage), 20);
   amr::AmrStaticAbility ability2(amr::LoadCarrier(amr::LoadCarrier::Types::kEuroBox), 20);

--- a/daisi/src/cpps/logical/amr/CMakeLists.txt
+++ b/daisi/src/cpps/logical/amr/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(daisi_cpps_logical_amr_amr_logical_agent
     PRIVATE
     solanet_uuid
     solanet_uuid_generator_sim
+    daisi_cpps_logical_message_material_flow_update
 )
 
 target_include_directories(daisi_cpps_amr_amr_description INTERFACE

--- a/daisi/src/cpps/logical/amr/amr_logical_agent.h
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.h
@@ -83,7 +83,7 @@ private:
 
   void logAmrInfos();
   void logPositionUpdate();
-  void logOrderUpdate();
+  void forwardOrderUpdate();
 
   void sendToPhysical(std::string payload);
 

--- a/daisi/src/cpps/logical/material_flow/CMakeLists.txt
+++ b/daisi/src/cpps/logical/material_flow/CMakeLists.txt
@@ -13,4 +13,6 @@ target_link_libraries(daisi_cpps_logical_material_flow_material_flow_logical_age
     PRIVATE
     solanet_uuid
     solanet_uuid_generator_sim
+    daisi_cpps_logical_algorithms_algorithm_config
+    daisi_cpps_logical_message_material_flow_update
 )

--- a/daisi/src/cpps/logical/message/CMakeLists.txt
+++ b/daisi/src/cpps/logical/message/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(daisi_cpps_logical_message_serializer
     daisi_cpps_logical_message_central_allocation_assignment_response
     daisi_cpps_logical_message_central_allocation_status_update
     daisi_cpps_logical_message_central_allocation_status_update_request
+    daisi_cpps_logical_message_material_flow_update
 
     PRIVATE
     solanet_serializer
@@ -25,4 +26,17 @@ target_link_libraries(daisi_cpps_logical_message_serializer
 target_include_directories(daisi_cpps_logical_message_serializer
     PUBLIC
     ${DAISI_SOURCE_DIR}/src
+)
+
+add_library(daisi_cpps_logical_message_material_flow_update INTERFACE)
+target_sources(daisi_cpps_logical_message_material_flow_update
+    INTERFACE
+    material_flow_update.h
+)
+target_link_libraries(daisi_cpps_logical_message_material_flow_update
+    INTERFACE
+    solanet_serializer
+    daisi_material_flow_model_task
+    daisi_cpps_model_order_states
+    daisi_structure_helpers
 )

--- a/daisi/src/cpps/logical/message/material_flow_update.h
+++ b/daisi/src/cpps/logical/message/material_flow_update.h
@@ -1,0 +1,41 @@
+// Copyright 2023 The SOLA authors
+//
+// This file is part of DAISI.
+//
+// DAISI is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation; version 2.
+//
+// DAISI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+// the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with DAISI. If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef DAISI_CPPS_LOGICAL_MESSAGE_MATERIAL_FLOW_UPDATE_H_
+#define DAISI_CPPS_LOGICAL_MESSAGE_MATERIAL_FLOW_UPDATE_H_
+
+#include <cstdint>
+#include <string>
+
+#include "cpps/model/order_states.h"
+#include "material_flow/model/task.h"
+#include "solanet/serializer/serialize.h"
+#include "utils/structure_helpers.h"
+
+namespace daisi::cpps::logical {
+
+struct MaterialFlowUpdate {
+  std::string amr_uuid;
+  OrderStates order_state;
+  material_flow::Task task;
+  uint8_t order_index = 0;
+  util::Position position;
+
+  SERIALIZE(amr_uuid, order_state, task, order_index, position);
+};
+}  // namespace daisi::cpps::logical
+
+#endif

--- a/daisi/src/cpps/logical/message/serializer.h
+++ b/daisi/src/cpps/logical/message/serializer.h
@@ -29,12 +29,14 @@
 #include "central_allocation/assignment_response.h"
 #include "central_allocation/status_update.h"
 #include "central_allocation/status_update_request.h"
+#include "material_flow_update.h"
 
 namespace daisi::cpps::logical {
 
-using Message = std::variant<CallForProposal, BidSubmission, IterationNotification,
-                             WinnerNotification, WinnerResponse, AssignmentNotification,
-                             AssignmentResponse, StatusUpdate, StatusUpdateRequest>;
+using Message =
+    std::variant<CallForProposal, BidSubmission, IterationNotification, WinnerNotification,
+                 WinnerResponse, AssignmentNotification, AssignmentResponse, StatusUpdate,
+                 StatusUpdateRequest, MaterialFlowUpdate>;
 
 std::string serialize(const Message &msg);
 

--- a/daisi/src/material_flow/model/task.cpp
+++ b/daisi/src/material_flow/model/task.cpp
@@ -21,9 +21,10 @@
 
 namespace daisi::material_flow {
 
-Task::Task(std::string name, const std::vector<Order> &orders,
+Task::Task(std::string name, std::string connection_string, const std::vector<Order> &orders,
            const std::vector<std::string> &follow_up_task_uuids)
     : name_(std::move(name)),
+      connection_string_(std::move(connection_string)),
       orders_(orders),
       follow_up_task_uuids_(std::move(follow_up_task_uuids)) {
   if (orders.empty()) {
@@ -36,6 +37,8 @@ Task::Task(std::string name, const std::vector<Order> &orders,
 const std::string &Task::getUuid() const { return uuid_; }
 
 const std::string &Task::getName() const { return name_; }
+
+const std::string &Task::getConnectionString() const { return connection_string_; }
 
 const std::vector<Order> &Task::getOrders() const { return orders_; }
 

--- a/daisi/src/material_flow/model/task.h
+++ b/daisi/src/material_flow/model/task.h
@@ -34,11 +34,13 @@ class Task {
 public:
   Task() = default;
 
-  Task(std::string name, const std::vector<Order> &orders,
+  Task(std::string name, std::string connection_string, const std::vector<Order> &orders,
        const std::vector<std::string> &follow_up_task_uuids);
 
   const std::string &getUuid() const;
   const std::string &getName() const;
+  const std::string &getConnectionString() const;
+
   const std::vector<Order> &getOrders() const;
   const std::vector<std::string> &getFollowUpTaskUuids() const;
 
@@ -57,12 +59,13 @@ public:
   bool operator==(const Task &other) const { return uuid_ == other.uuid_; }
   bool operator!=(const Task &other) const { return uuid_ != other.uuid_; }
 
-  SERIALIZE(uuid_, name_, orders_, follow_up_task_uuids_, preceding_task_uuids_,
+  SERIALIZE(uuid_, name_, connection_string_, orders_, follow_up_task_uuids_, preceding_task_uuids_,
             ability_requirement_);
 
 private:
   std::string uuid_;
   std::string name_;
+  std::string connection_string_;
 
   std::vector<Order> orders_;
 

--- a/daisi/tests/unittests/cpps/logical/auction_participant_state_test.cpp
+++ b/daisi/tests/unittests/cpps/logical/auction_participant_state_test.cpp
@@ -31,17 +31,17 @@ std::vector<Task> getThreeTasks() {
   TransportOrderStep pickup1("tos11", {}, Location("0x0", "type", util::Position(10, 10)));
   TransportOrderStep delivery1("tos12", {}, Location("0x0", "type", util::Position(10, 20)));
   TransportOrder to1({pickup1}, delivery1);
-  Task task1("task1", {to1}, {});
+  Task task1("task1", "127.0.0.1:5000", {to1}, {});
 
   TransportOrderStep pickup2("tos21", {}, Location("0x0", "type", util::Position(20, 10)));
   TransportOrderStep delivery2("tos22", {}, Location("0x0", "type", util::Position(10, 20)));
   TransportOrder to2({pickup2}, delivery2);
-  Task task2("task2", {to2}, {});
+  Task task2("task2", "127.0.0.1:5000", {to2}, {});
 
   TransportOrderStep pickup3("tos31", {}, Location("0x0", "type", util::Position(10, 20)));
   TransportOrderStep delivery3("tos32", {}, Location("0x0", "type", util::Position(5, 5)));
   TransportOrder to3({pickup3}, delivery3);
-  Task task3("task3", {to3}, {});
+  Task task3("task3", "127.0.0.1:5000", {to3}, {});
 
   amr::AmrStaticAbility ability1(amr::LoadCarrier(amr::LoadCarrier::Types::kPackage), 20);
   amr::AmrStaticAbility ability2(amr::LoadCarrier(amr::LoadCarrier::Types::kEuroBox), 20);

--- a/daisi/tests/unittests/cpps/order_management/simple_order_management_test.cpp
+++ b/daisi/tests/unittests/cpps/order_management/simple_order_management_test.cpp
@@ -55,12 +55,12 @@ TEST_CASE("SimpleOrderManagement Empty Tasks", "[adding and removing vertices]")
   REQUIRE(!management.setNextTask());
 
   // empty task
-  Task task_empty("task1", {}, {});
+  Task task_empty("task1", "127.0.0.1:5000", {}, {});
   REQUIRE_THROWS(management.canAddTask(task_empty));
   REQUIRE_THROWS(management.addTask(task_empty));
 
   // empty task with follow ups
-  Task task_empty_with_follow_ups("task2", {}, {"task1", "task3"});
+  Task task_empty_with_follow_ups("task2", "127.0.0.1:5000", {}, {"task1", "task3"});
   REQUIRE_THROWS(management.canAddTask(task_empty_with_follow_ups));
   REQUIRE_THROWS(management.addTask(task_empty_with_follow_ups));
 }
@@ -79,7 +79,7 @@ TEST_CASE("SimpleOrderManagement One Simple Transport Order", "[adding and remov
   TransportOrderStep pickup1("tos1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery1("tos2", {}, Location("0x1", "type", p2));
   TransportOrder simple_to("simple_to", {pickup1}, delivery1);
-  Task simple_task("simple_task", {simple_to}, {});
+  Task simple_task("simple_task", "127.0.0.1:5000", {simple_to}, {});
 
   // act
   auto opt_result = management.canAddTask(simple_task);
@@ -132,13 +132,13 @@ TEST_CASE("SimpleOrderManagement Two Simple Transport Orders", "[adding and remo
   TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
   TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
-  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+  Task simple_task_1("simple_task_1", "127.0.0.1:5000", {simple_to_1}, {});
 
   // transport order 2
   TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p4));
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p3));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
-  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+  Task simple_task_2("simple_task_2", "127.0.0.1:5000", {simple_to_2}, {});
 
   // can add tests
   auto can_add_1 = management.canAddTask(simple_task_1);
@@ -207,13 +207,13 @@ TEST_CASE("SimpleOrderManagement Two Simple Transport Orders multiple times",
   TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
   TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
-  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+  Task simple_task_1("simple_task_1", "127.0.0.1:5000", {simple_to_1}, {});
 
   // transport order 2
   TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p4));
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p3));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
-  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+  Task simple_task_2("simple_task_2", "127.0.0.1:5000", {simple_to_2}, {});
 
   // adding and removing task 2
   REQUIRE(!management.hasTasks());
@@ -288,19 +288,19 @@ TEST_CASE("SimpleOrderManagement Three Simple Transport Orders", "[adding and re
   TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p3));
   TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
   TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
-  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+  Task simple_task_1("simple_task_1", "127.0.0.1:5000", {simple_to_1}, {});
 
   // transport order 2
   TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p6));
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p5));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
-  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+  Task simple_task_2("simple_task_2", "127.0.0.1:5000", {simple_to_2}, {});
 
   // transport order 3
   TransportOrderStep pickup_3("tos1_3", {}, Location("0x4", "type", p1));
   TransportOrderStep delivery_3("tos2_3", {}, Location("0x5", "type", p0));
   TransportOrder simple_to_3("simple_to_3", {pickup_3}, delivery_3);
-  Task simple_task_3("simple_task_3", {simple_to_3}, {});
+  Task simple_task_3("simple_task_3", "127.0.0.1:5000", {simple_to_3}, {});
 
   auto add_1_opt = management.addTask(simple_task_1);
   auto add_1_metrics = management.getFinalMetrics();
@@ -338,7 +338,7 @@ TEST_CASE("SimpleOrderManagement Two Transport Orders in one Task",
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p4));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
 
-  Task task_1("task_1", {simple_to_1, simple_to_2}, {});
+  Task task_1("task_1", "127.0.0.1:5000", {simple_to_1, simple_to_2}, {});
 
   auto add_1_opt = management.addTask(task_1);
   REQUIRE(add_1_opt);
@@ -367,7 +367,7 @@ TEST_CASE("SimpleOrderManagement One Transport, Move, and Action Order in one Ta
   ActionOrder ao_1("ao", aos);
 
   // try to add an illformed task, since a MoveOrder should not be the first order
-  Task task_1("task_1", {mo_1, to_1, ao_1}, {});
+  Task task_1("task_1", "127.0.0.1:5000", {mo_1, to_1, ao_1}, {});
   REQUIRE_THROWS(management.addTask(task_1));
 
   // current metrics should be unchanged
@@ -381,7 +381,7 @@ TEST_CASE("SimpleOrderManagement One Transport, Move, and Action Order in one Ta
   REQUIRE(metrics.getDistance() == 0);
   REQUIRE(metrics.getMakespan() == 0);
 
-  Task task_2("task_2", {to_1, mo_1, ao_1}, {});
+  Task task_2("task_2", "127.0.0.1:5000", {to_1, mo_1, ao_1}, {});
 
   auto add_opt = management.addTask(task_2);
   REQUIRE(add_opt);
@@ -408,19 +408,19 @@ TEST_CASE("Simple Order Management Three Simple Transport Orders with time delay
   TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p3));
   TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
   TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
-  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+  Task simple_task_1("simple_task_1", "127.0.0.1:5000", {simple_to_1}, {});
 
   // transport order 2
   TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p6));
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p5));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
-  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+  Task simple_task_2("simple_task_2", "127.0.0.1:5000", {simple_to_2}, {});
 
   // transport order 3
   TransportOrderStep pickup_3("tos1_3", {}, Location("0x4", "type", p1));
   TransportOrderStep delivery_3("tos2_3", {}, Location("0x5", "type", p0));
   TransportOrder simple_to_3("simple_to_3", {pickup_3}, delivery_3);
-  Task simple_task_3("simple_task_3", {simple_to_3}, {});
+  Task simple_task_3("simple_task_3", "127.0.0.1:5000", {simple_to_3}, {});
 
   auto add_1_opt = management.addTask(simple_task_1);
   auto add_1_metrics = management.getFinalMetrics();

--- a/daisi/tests/unittests/cpps/order_management/stn_order_management_test.cpp
+++ b/daisi/tests/unittests/cpps/order_management/stn_order_management_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE("One Simple Transport Order", "[basic]") {
   TransportOrderStep pickup1("tos1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery1("tos2", {}, Location("0x1", "type", p2));
   TransportOrder simple_to("simple_to", {pickup1}, delivery1);
-  Task simple_task("simple_task", {simple_to}, {});
+  Task simple_task("simple_task", "127.0.0.1:5000", {simple_to}, {});
 
   // act
 
@@ -119,13 +119,13 @@ TEST_CASE("Two Simple Transport Orders statically", "[basic]") {
   TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
   TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
-  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+  Task simple_task_1("simple_task_1", "127.0.0.1:5000", {simple_to_1}, {});
 
   // transport order 2 without constraints
   TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p4));
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p3));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
-  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+  Task simple_task_2("simple_task_2", "127.0.0.1:5000", {simple_to_2}, {});
 
   // can add tests
   REQUIRE(management.canAddTask(simple_task_1));
@@ -206,13 +206,13 @@ TEST_CASE("Two Simple Transport Orders dynamically", "[basic]") {
   TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
   TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
-  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+  Task simple_task_1("simple_task_1", "127.0.0.1:5000", {simple_to_1}, {});
 
   // transport order 2 without constraints
   TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p4));
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p3));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
-  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+  Task simple_task_2("simple_task_2", "127.0.0.1:5000", {simple_to_2}, {});
 
   // add task 1 and setting it dynamically to the next task
   REQUIRE(management.addTask(simple_task_1));
@@ -282,19 +282,19 @@ TEST_CASE("Three Simple Transport Orders statically", "[basic]") {
   TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p3));
   TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
   TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
-  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+  Task simple_task_1("simple_task_1", "127.0.0.1:5000", {simple_to_1}, {});
 
   // transport order 2 without constraints
   TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p6));
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p5));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
-  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+  Task simple_task_2("simple_task_2", "127.0.0.1:5000", {simple_to_2}, {});
 
   // transport order 3 without constraints
   TransportOrderStep pickup_3("tos1_3", {}, Location("0x4", "type", p1));
   TransportOrderStep delivery_3("tos2_3", {}, Location("0x5", "type", p0));
   TransportOrder simple_to_3("simple_to_3", {pickup_3}, delivery_3);
-  Task simple_task_3("simple_task_3", {simple_to_3}, {});
+  Task simple_task_3("simple_task_3", "127.0.0.1:5000", {simple_to_3}, {});
 
   REQUIRE(management.addTask(simple_task_1));
   auto add_1 = management.getLatestCalculatedInsertionInfo();
@@ -342,7 +342,7 @@ TEST_CASE("Two Transport Orders in one Task", "[basic]") {
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p4));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
 
-  Task task_1("task_1", {simple_to_1, simple_to_2}, {});
+  Task task_1("task_1", "127.0.0.1:5000", {simple_to_1, simple_to_2}, {});
 
   REQUIRE(management.addTask(task_1));
   auto add_1_metrics_comp = management.getLatestCalculatedInsertionInfo().first;
@@ -366,7 +366,7 @@ TEST_CASE("One Transport, Move, and Action Order in one Task", "[basic]") {
   ActionOrderStep aos("aos", {{"load", "load"}});
   ActionOrder ao_1("ao", aos);
 
-  Task task_1("task_1", {to_1, mo_1, ao_1}, {});
+  Task task_1("task_1", "127.0.0.1:5000", {to_1, mo_1, ao_1}, {});
 
   REQUIRE(management.addTask(task_1));
   auto add_1_metrics_comp = management.getLatestCalculatedInsertionInfo().first;
@@ -385,7 +385,7 @@ TEST_CASE("One Simple Transport Order with Time Window", "[temporal]") {
   TransportOrderStep pickup1("tos1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery1("tos2", {}, Location("0x1", "type", p2));
   TransportOrder simple_to("simple_to", {pickup1}, delivery1);
-  Task simple_task("simple_task", {simple_to}, {});
+  Task simple_task("simple_task", "127.0.0.1:5000", {simple_to}, {});
 
   TimeWindow time_window(40, 140, 0);
   simple_task.setTimeWindow(time_window);
@@ -428,7 +428,7 @@ TEST_CASE("One Simple Transport Order with too short Time Window", "[temporal]")
   TransportOrderStep pickup1("tos1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery1("tos2", {}, Location("0x1", "type", p2));
   TransportOrder simple_to("simple_to", {pickup1}, delivery1);
-  Task simple_task("simple_task", {simple_to}, {});
+  Task simple_task("simple_task", "127.0.0.1:5000", {simple_to}, {});
 
   simple_task.setTimeWindow(TimeWindow(40, 70, 0));
   REQUIRE(management.canAddTask(simple_task));
@@ -476,13 +476,13 @@ TEST_CASE("Two Simple Transport Orders with overlapping Time Windows", "[tempora
   TransportOrderStep pickup_1("tos1_1", {}, Location("0x0", "type", p1));
   TransportOrderStep delivery_1("tos2_1", {}, Location("0x1", "type", p2));
   TransportOrder simple_to_1("simple_to_1", {pickup_1}, delivery_1);
-  Task simple_task_1("simple_task_1", {simple_to_1}, {});
+  Task simple_task_1("simple_task_1", "127.0.0.1:5000", {simple_to_1}, {});
 
   // transport order 2
   TransportOrderStep pickup_2("tos1_2", {}, Location("0x2", "type", p4));
   TransportOrderStep delivery_2("tos2_2", {}, Location("0x3", "type", p3));
   TransportOrder simple_to_2("simple_to_2", {pickup_2}, delivery_2);
-  Task simple_task_2("simple_task_2", {simple_to_2}, {});
+  Task simple_task_2("simple_task_2", "127.0.0.1:5000", {simple_to_2}, {});
 
   simple_task_1.setTimeWindow(TimeWindow(0, 40, 0));
   simple_task_2.setTimeWindow(TimeWindow(0, 80, 0));

--- a/evaluation/cpps/verification.py
+++ b/evaluation/cpps/verification.py
@@ -21,14 +21,12 @@ def evaluate_database(path):
             [[mf_count]] = db.fetch_all(
                 "SELECT COUNT(DISTINCT MaterialFlowOrderId) FROM MaterialFlowOrderHistory")
             for i in range(1, mf_count+1):
-                sql_query = "SELECT Timestamp_ms/10 as t, State FROM MaterialFlowOrderHistory WHERE MaterialFlowOrderId = " + \
-                    str(i) + " ORDER BY t"
+                sql_query = "SELECT Timestamp_ms, State FROM MaterialFlowOrderHistory WHERE MaterialFlowOrderId = " + \
+                    str(i) + " ORDER BY Timestamp_ms, State"
                 result = db.fetch_all(sql_query)
                 # check if all states are met
                 j = 0
                 element_valid = True
-
-                result = sorted(result, key=lambda x: x[0]*100 + x[1])
 
                 for res in result:
                     # allow multiple load actions


### PR DESCRIPTION
Previously, only the AMR was aware of the current order states. Updates were not shared with the MF agent. Update logging was (partially) done from the logical AMR itself.

Now, the update is sent to the MF agent through unicast messages. The MF logger contains a logger "algorithm" that processes these messages.
