### PR TITLE
Use ns-3 context to get device ID for logging

### DIFF
--- a/daisi/src/cpps/common/cpps_manager.cpp
+++ b/daisi/src/cpps/common/cpps_manager.cpp
@@ -73,8 +73,6 @@ void CppsManager::spawnAMR(uint32_t amr_index, const AmrDescription &description
                            const Topology &topology) {
   std::cout << "Creating AMR " << description.getProperties().getFriendlyName() << std::endl;
 
-  const uint32_t device_id = amrs_.Get(amr_index)->GetId();
-
   if (next_mobility_model != nullptr) {
     throw std::runtime_error("mobility model not empty");
   }
@@ -92,7 +90,7 @@ void CppsManager::spawnAMR(uint32_t amr_index, const AmrDescription &description
       std::make_shared<AmrPhysicalAsset>(std::move(connector));
   this->amrs_.Get(amr_index)->GetApplication(0)->GetObject<CppsApplication>()->application =
       std::make_shared<logical::AmrLogicalAgent>(
-          device_id, scenario_.algorithm.getParticipantAlgorithmConfig(), amr_index == 0);
+          scenario_.algorithm.getParticipantAlgorithmConfig(), amr_index == 0);
 }
 
 void CppsManager::setup() {
@@ -184,13 +182,11 @@ void CppsManager::startAMR(uint32_t index) {
 }
 
 void CppsManager::initMF(uint32_t index) {
-  const uint32_t device_id = material_flows_.Get(index)->GetId();
-
   std::cout << "Creating MF Logical Agent " << index << std::endl;
 
   this->material_flows_.Get(index)->GetApplication(0)->GetObject<CppsApplication>()->application =
       std::make_shared<logical::MaterialFlowLogicalAgent>(
-          device_id, scenario_.algorithm.getInitiatorAlgorithmConfig(), false);
+          scenario_.algorithm.getInitiatorAlgorithmConfig(), false);
 
   std::cout << "Init MF Logical Agent " << index << std::endl;
 

--- a/daisi/src/cpps/logical/amr/amr_logical_agent.cpp
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.cpp
@@ -29,8 +29,8 @@
 
 namespace daisi::cpps::logical {
 
-AmrLogicalAgent::AmrLogicalAgent(uint32_t device_id, const AlgorithmConfig &config, bool first_node)
-    : LogicalAgent(device_id, daisi::global_logger_manager->createAMRLogger(), config, first_node),
+AmrLogicalAgent::AmrLogicalAgent(const AlgorithmConfig &config, bool first_node)
+    : LogicalAgent(daisi::global_logger_manager->createAMRLogger(), config, first_node),
       topology_(daisi::util::Dimensions(50, 20, 0))  // TODO placeholder
 {}
 

--- a/daisi/src/cpps/logical/amr/amr_logical_agent.cpp
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.cpp
@@ -30,8 +30,7 @@
 namespace daisi::cpps::logical {
 
 AmrLogicalAgent::AmrLogicalAgent(uint32_t device_id, const AlgorithmConfig &config, bool first_node)
-    : LogicalAgent(device_id, daisi::global_logger_manager->createAMRLogger(device_id), config,
-                   first_node),
+    : LogicalAgent(device_id, daisi::global_logger_manager->createAMRLogger(), config, first_node),
       topology_(daisi::util::Dimensions(50, 20, 0))  // TODO placeholder
 {}
 

--- a/daisi/src/cpps/logical/amr/amr_logical_agent.h
+++ b/daisi/src/cpps/logical/amr/amr_logical_agent.h
@@ -34,7 +34,7 @@ namespace daisi::cpps::logical {
 
 class AmrLogicalAgent : public LogicalAgent {
 public:
-  AmrLogicalAgent(uint32_t device_id, const AlgorithmConfig &config, bool first_node);
+  AmrLogicalAgent(const AlgorithmConfig &config, bool first_node);
 
   ~AmrLogicalAgent() override = default;
 

--- a/daisi/src/cpps/logical/logical_agent.cpp
+++ b/daisi/src/cpps/logical/logical_agent.cpp
@@ -25,10 +25,9 @@
 
 namespace daisi::cpps::logical {
 
-LogicalAgent::LogicalAgent(uint32_t device_id, std::shared_ptr<CppsLoggerNs3> logger,
-                           AlgorithmConfig config_algo, bool first_node)
-    : device_id_(device_id),
-      logger_(std::move(logger)),
+LogicalAgent::LogicalAgent(std::shared_ptr<CppsLoggerNs3> logger, AlgorithmConfig config_algo,
+                           bool first_node)
+    : logger_(std::move(logger)),
       algorithm_config_(std::move(config_algo)),
       first_node_(first_node) {}
 

--- a/daisi/src/cpps/logical/logical_agent.h
+++ b/daisi/src/cpps/logical/logical_agent.h
@@ -30,8 +30,7 @@ namespace daisi::cpps::logical {
 
 class LogicalAgent {
 public:
-  LogicalAgent(uint32_t device_id, std::shared_ptr<CppsLoggerNs3> logger,
-               AlgorithmConfig config_algo, bool first_node);
+  LogicalAgent(std::shared_ptr<CppsLoggerNs3> logger, AlgorithmConfig config_algo, bool first_node);
 
   virtual ~LogicalAgent() = default;
 
@@ -67,9 +66,6 @@ protected:
   /// @brief Method being called by sola when we receive a message via a topic
   /// @param m received message
   virtual void topicMessageReceiveFunction(const sola::TopicMessage &msg) = 0;
-
-  /// @brief Needed for initialization of Sola.
-  uint32_t device_id_;
 
   /// @brief The algorithms which logical messages will be forwarded to for processing.
   std::vector<std::unique_ptr<AlgorithmInterface>> algorithms_;

--- a/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.cpp
+++ b/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.cpp
@@ -47,11 +47,9 @@ private:
   std::shared_ptr<CppsLoggerNs3> logger_;
 };
 
-MaterialFlowLogicalAgent::MaterialFlowLogicalAgent(uint32_t device_id,
-                                                   const AlgorithmConfig &config_algo,
+MaterialFlowLogicalAgent::MaterialFlowLogicalAgent(const AlgorithmConfig &config_algo,
                                                    bool first_node)
-    : LogicalAgent(device_id, daisi::global_logger_manager->createTOLogger(), config_algo,
-                   first_node) {}
+    : LogicalAgent(daisi::global_logger_manager->createTOLogger(), config_algo, first_node) {}
 
 void MaterialFlowLogicalAgent::init() { initCommunication(); }
 

--- a/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.cpp
+++ b/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.cpp
@@ -50,7 +50,7 @@ private:
 MaterialFlowLogicalAgent::MaterialFlowLogicalAgent(uint32_t device_id,
                                                    const AlgorithmConfig &config_algo,
                                                    bool first_node)
-    : LogicalAgent(device_id, daisi::global_logger_manager->createTOLogger(device_id), config_algo,
+    : LogicalAgent(device_id, daisi::global_logger_manager->createTOLogger(), config_algo,
                    first_node) {}
 
 void MaterialFlowLogicalAgent::init() { initCommunication(); }

--- a/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.h
+++ b/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.h
@@ -24,7 +24,7 @@ namespace daisi::cpps::logical {
 
 class MaterialFlowLogicalAgent : public LogicalAgent {
 public:
-  MaterialFlowLogicalAgent(uint32_t device_id, const AlgorithmConfig &config_algo, bool first_node);
+  MaterialFlowLogicalAgent(const AlgorithmConfig &config_algo, bool first_node);
 
   /// @brief Includes leaving Sola.
   ~MaterialFlowLogicalAgent() override = default;  // TODO

--- a/daisi/src/logging/CMakeLists.txt
+++ b/daisi/src/logging/CMakeLists.txt
@@ -35,4 +35,5 @@ target_link_libraries(daisi_logger_manager
     daisi_sola_logger_ns3
     PRIVATE
     ns3::libcore
+    daisi_utils
 )

--- a/daisi/src/logging/logger_manager.h
+++ b/daisi/src/logging/logger_manager.h
@@ -54,20 +54,20 @@ public:
 
   void logDevice(uint32_t id);
   void logDeviceApplication(const std::string &application_uuid,
-                            const std::string &application_name, uint32_t device_id);
+                            const std::string &application_name);
   void logEvent(const std::string &event_uuid, uint16_t event_type,
                 const std::string &application_uuid);
 
   void logMinhtonConfigFile(const std::string &file_path);
 
   std::shared_ptr<minhton::MinhtonLoggerNs3> createMinhtonLogger(
-      uint32_t device_id, const std::string &app_name_postfix = "");
-  std::shared_ptr<natter::logging::NatterLoggerNs3> createNatterLogger(uint32_t device_id);
-  std::shared_ptr<daisi::cpps::CppsLoggerNs3> createAMRLogger(uint32_t device_id);
-  std::shared_ptr<daisi::cpps::CppsLoggerNs3> createTOLogger(uint32_t device_id);
+      const std::string &app_name_postfix = "");
+  std::shared_ptr<natter::logging::NatterLoggerNs3> createNatterLogger();
+  std::shared_ptr<daisi::cpps::CppsLoggerNs3> createAMRLogger();
+  std::shared_ptr<daisi::cpps::CppsLoggerNs3> createTOLogger();
   // std::shared_ptr<daisi::path_planning::PathPlanningLoggerNs3> createPathPlanningLogger(
-  //     uint32_t device_id, const std::string &device_type = "");
-  std::shared_ptr<sola_ns3::SolaLoggerNs3> createSolaLogger(uint32_t device_id);
+  //     const std::string &device_type = "");
+  std::shared_ptr<sola_ns3::SolaLoggerNs3> createSolaLogger();
 
 private:
   daisi::SQLiteHelper sqlite_helper_;

--- a/daisi/src/minhton-ns3/minhton_application.cpp
+++ b/daisi/src/minhton-ns3/minhton_application.cpp
@@ -41,7 +41,7 @@ void MinhtonApplication::DoDispose() {
 }
 
 void MinhtonApplication::StartApplication() {
-  logger_ = daisi::global_logger_manager->createMinhtonLogger(GetNode()->GetId());
+  logger_ = daisi::global_logger_manager->createMinhtonLogger();
 }
 
 void MinhtonApplication::StopApplication() {}

--- a/daisi/src/natter-ns3/natter_application.cpp
+++ b/daisi/src/natter-ns3/natter_application.cpp
@@ -37,7 +37,7 @@ void NatterApplication::DoDispose() {
 }
 
 void NatterApplication::StartApplication() {
-  logger_ = daisi::global_logger_manager->createNatterLogger(GetNode()->GetId());
+  logger_ = daisi::global_logger_manager->createNatterLogger();
 
   natter_node_ = Create<NatterNodeNs3>(logger_, mode_);
 }

--- a/daisi/src/sola-ns3/CMakeLists.txt
+++ b/daisi/src/sola-ns3/CMakeLists.txt
@@ -104,6 +104,4 @@ target_link_libraries(sola_config_helper_ns3 INTERFACE
         ManagementOverlayMINHTONSim
         EventDisseminationMinhcastSim
         daisi_logger_manager
-        ns3::libcore
-        daisi_utils
 )

--- a/daisi/src/sola-ns3/config_helper_ns3.h
+++ b/daisi/src/sola-ns3/config_helper_ns3.h
@@ -20,28 +20,20 @@
 #include "SOLA/event_dissemination_minhcast.h"
 #include "SOLA/management_overlay_minhton.h"
 #include "logging/logger_manager.h"
-#include "ns3/simulator.h"
-#include "utils/daisi_check.h"
 
 namespace daisi::sola_ns3 {
 
 inline void configureLogger(sola::ManagementOverlayMinhton::Config &config) {
-  const uint64_t device_id = ns3::Simulator::GetContext();
-  DAISI_CHECK(device_id != ns3::Simulator::NO_CONTEXT, "Context not set");
-
   config.setLogger(std::vector<sola::ManagementOverlayMinhton::Logger>{
-      daisi::global_logger_manager->createMinhtonLogger(device_id, "MO")});
+      daisi::global_logger_manager->createMinhtonLogger("MO")});
 }
 
 inline void configureLogger(sola::EventDisseminationMinhcast::Config &config) {
-  const uint64_t device_id = ns3::Simulator::GetContext();
-  DAISI_CHECK(device_id != ns3::Simulator::NO_CONTEXT, "Context not set");
-
   config.logger = std::vector<sola::EventDisseminationMinhcast::Logger>{
-      daisi::global_logger_manager->createNatterLogger(device_id)};
-  config.topic_tree_logger_create_fct = [device_id](const std::string &topic) {
+      daisi::global_logger_manager->createNatterLogger()};
+  config.topic_tree_logger_create_fct = [](const std::string &topic) {
     const std::string postfix = "ED:" + topic;
-    return daisi::global_logger_manager->createMinhtonLogger(device_id, postfix);
+    return daisi::global_logger_manager->createMinhtonLogger(postfix);
   };
 }
 

--- a/daisi/src/sola-ns3/sola_application.cpp
+++ b/daisi/src/sola-ns3/sola_application.cpp
@@ -80,7 +80,7 @@ void SolaApplication::startSOLA() {
               << msg.sender << std::endl;
   };
 
-  auto logger = daisi::global_logger_manager->createSolaLogger(GetNode()->GetId());
+  auto logger = daisi::global_logger_manager->createSolaLogger();
   sola_ = std::make_unique<sola_ns3::SOLAWrapperNs3>(config_mo, config_ed, single_receive,
                                                      topic_receive, logger,
                                                      "");  // Already joining overlay network


### PR DESCRIPTION
Starting with https://github.com/iml130/sola/commit/a9bd526a784f40f0518bf64ce4125e9dbd8be689, the ns-3 context equals the ns-3 node ID on which the function is called (at least on initialization).

With this PR, the ns-3 context is used to get the device ID (which is the ns-3 node ID) for logging, instead of passing it through the entire application.