### PR TITLE
fix(cpps): position  update in AmrMobilityHelper.calculateMobilityStatus

### DIFF
--- a/daisi/src/cpps/amr/amr_mobility_helper.cpp
+++ b/daisi/src/cpps/amr/amr_mobility_helper.cpp
@@ -133,8 +133,10 @@ AmrMobilityStatus AmrMobilityHelper::calculateMobilityStatus(
       break;
     case AmrMobilityState::kDecelerating:
       status = current_phase;
+      // status.acceleration is pointing in the opposite direction of status.velocity during
+      // deceleration
       status.position +=
-          status.velocity * delta_t - 1 / 2.0 * status.acceleration * delta_t * delta_t;
+          status.velocity * delta_t + 1 / 2.0 * status.acceleration * delta_t * delta_t;
       status.velocity += status.acceleration * delta_t;
       break;
     default:

--- a/daisi/src/cpps/amr/amr_mobility_helper.h
+++ b/daisi/src/cpps/amr/amr_mobility_helper.h
@@ -53,7 +53,8 @@ public:
                                          const AmrDescription &description,
                                          const Topology &topology, bool check_positioning = true);
 
-  /// @brief Calculates acceleration, constant velocity and deceleration phases for simulation.
+  /// @brief Calculates acceleration, constant velocity and deceleration phases for simulation. The
+  /// deceleration vector is pointing in the opposite direction of the velocity vector.
   /// @throws \c std::invalid_argument
   /// * if \c start_pose or any other Position is outside of \c Topology or
   /// * if a requested \c FunctionalityVariant is missing in description

--- a/daisi/tests/unittests/cpps/amr/amr_mobility_helper_test.cpp
+++ b/daisi/tests/unittests/cpps/amr/amr_mobility_helper_test.cpp
@@ -1282,11 +1282,9 @@ TEST_CASE("calculateMobilityStatus )", "[mobility_helper]") {
     result = AmrMobilityHelper::calculateMobilityStatus(status, status.timestamp + 1);
     REQUIRE(result.acceleration == status.acceleration);
 
-    if (status.state == AmrMobilityState::kDecelerating) {
-      REQUIRE(result.position == status.position + status.velocity - 1 / 2.0 * status.acceleration);
-    } else {
-      REQUIRE(result.position == status.position + status.velocity + 1 / 2.0 * status.acceleration);
-    }
+    // in deceleration phase the status.acceleration vector points in the opposite direction of the
+    // velocity vector
+    REQUIRE(result.position == status.position + status.velocity + 1 / 2.0 * status.acceleration);
 
     REQUIRE(result.state == status.state);
     REQUIRE(result.timestamp == status.timestamp + 1);


### PR DESCRIPTION
In the deceleration phase the position of the AMR's is temporarily wrong. 
This is because in the deceleration phase:

1. `AmrMobilityHelper.calculatePhases` generates an acceleration vector that points in the opposite direction of the velocity vector 
2. `AmrMoobilityHelper.calculateMobilityStatus` subtracts the distance vector resulting from the acceleration vector. This effectively adds distance travelled to the calculated position. Because of this the AMR "overshoots" the stopping point.
3. The test uses the same wrong calculation and did not find the error

This PR corrects the error by adding the acceleration vector instead of subtracting it.
Also the description of `AmrMobilityHelper.calculatePhases` was complemented by the notion about the acceleration vector.