### PR TITLE
Parse scenariofile in constructor and adding helper function to deserialize std::variant-like types.

### DIFF
--- a/daisi/src/cpps/common/cpps_manager.cpp
+++ b/daisi/src/cpps/common/cpps_manager.cpp
@@ -76,8 +76,6 @@ CppsManager::CppsManager(const std::string &scenario_config_file)
     : Manager<CppsApplication>(scenario_config_file), scenario_(scenario_config_file) {
   Manager::initLogger();
 
-  scenario_.parse();
-
   amr_descriptions_ = scenario_.getAmrDescriptions();
   material_flow_descriptions_ = scenario_.getMaterialFlowDescriptions();
 

--- a/daisi/src/cpps/common/scenariofile/cpps_scenariofile.h
+++ b/daisi/src/cpps/common/scenariofile/cpps_scenariofile.h
@@ -80,24 +80,7 @@ struct AlgorithmScenario {
 };
 
 struct CppsScenariofile : public GeneralScenariofile {
-  explicit CppsScenariofile(const std::string &path_to_file) : GeneralScenariofile(path_to_file) {}
-
-  uint16_t initial_number_of_amrs = 0;
-  uint16_t number_of_material_flows = 0;
-  uint16_t number_of_material_flow_agents = 0;
-
-  bool do_material_flow_agents_leave_after_finish = false;
-
-  AlgorithmScenario algorithm;
-  TopologyScenario topology;
-
-  std::vector<AmrDescriptionScenario> autonomous_mobile_robots;
-  std::vector<MaterialFlowDescriptionScenario> material_flows;
-  std::vector<SpawnInfoScenario> scenario_sequence;
-
-  void parse() override {
-    GeneralScenariofile::parse();
-
+  explicit CppsScenariofile(const std::string &path_to_file) : GeneralScenariofile(path_to_file) {
     SERIALIZE_VAR(initial_number_of_amrs);
     SERIALIZE_VAR(number_of_material_flows);
     SERIALIZE_VAR(number_of_material_flow_agents);
@@ -114,6 +97,19 @@ struct CppsScenariofile : public GeneralScenariofile {
     verifyScenarioSequenceOfAmrs();
     calcNumbersOfRelativeAmrDistribution();
   }
+
+  uint16_t initial_number_of_amrs = 0;
+  uint16_t number_of_material_flows = 0;
+  uint16_t number_of_material_flow_agents = 0;
+
+  bool do_material_flow_agents_leave_after_finish = false;
+
+  AlgorithmScenario algorithm;
+  TopologyScenario topology;
+
+  std::vector<AmrDescriptionScenario> autonomous_mobile_robots;
+  std::vector<MaterialFlowDescriptionScenario> material_flows;
+  std::vector<SpawnInfoScenario> scenario_sequence;
 
   std::unordered_map<std::string, AmrDescription> getAmrDescriptions() const;
   std::unordered_map<std::string, MaterialFlowDescriptionScenario> getMaterialFlowDescriptions()

--- a/daisi/src/manager/general_scenariofile.h
+++ b/daisi/src/manager/general_scenariofile.h
@@ -29,9 +29,7 @@ struct GeneralScenariofile {
       : file_path_(std::move(path_to_file)) {
     loadFileContent();
     node = YAML::Load(file_content_);
-  }
 
-  virtual void parse() {
     SERIALIZE_VAR(title);
     SERIALIZE_VAR(version);
 

--- a/daisi/src/manager/scenariofile_component.h
+++ b/daisi/src/manager/scenariofile_component.h
@@ -65,6 +65,26 @@ void serializeType(std::optional<T> &t, const std::string &key, YAML::Node node)
   }
 }
 
+/// @brief Deserialize data from node into variant with type T, if \p type matches
+/// T.typeName()
+/// @tparam T The type to parse if \p type matches \p req_type
+/// @param node the YAML node to read data from
+/// @param var variant to which the deserialized object is put
+/// @param type the actual type
+/// @return true if data was deserialzied
+template <typename T, typename... U>
+bool deserializeIf(YAML::Node node, std::variant<U...> &var, const std::string &type) {
+  if (type == T::typeName()) {
+    var.template emplace<T>();
+
+    // Do parsing of the actual object
+    std::get<T>(var).parse(node);
+
+    return true;
+  }
+  return false;
+}
+
 }  // namespace daisi
 
 #endif


### PR DESCRIPTION
# Proposed Changes
For simplification and to avoid the use of wrong data from the scenariofile parser: Directly parse the scenariofile in the constructor.

This PR also adds a function to deserialize YAML entries into std::variant-like types.  This will be used in the future for a type-safe list of all different scenario sequence steps.

# Definition of Done (optional)
- [x] Feature is implemented
- [x] No known bugs that stops the correct execution
- [x] CI / CD pipeline passed
- [x] The code guidelines were followed
- ~[ ] Unit and / or Integration tests for the new feature~
- ~[ ] New feature was added to the documentation~
