### PR TITLE
refactor(daisi): Remove application-specific fields from General table

### DIFF
--- a/daisi/src/logging/logger_manager.cpp
+++ b/daisi/src/logging/logger_manager.cpp
@@ -93,11 +93,10 @@ void LoggerManager::logEvent(const std::string &event_uuid, uint16_t event_type,
 // * General
 TableDefinition kGeneral("General", {{"StartTime_ut", "%lu", true},
                                      {"StopTime_ut", "%lu", true},
-                                     {"NumberOfNodes", "%lu", true},
                                      {"NumberOfEvents", "%lu", true},
-                                     {"Fanout", "%u"},
                                      {"Exception", "%s"},
-                                     {"Config", "%s"}});
+                                     {"Config", "%s"},
+                                     {"AdditionalParameters", "%s"}});
 const std::string kCreateGeneral = getCreateTableStatement(kGeneral);
 std::vector<std::string> general_updates_;
 
@@ -112,11 +111,10 @@ void LoggerManager::logTestSetup(const LoggerInfoTestSetup &info) {
   auto t = std::make_tuple(
       /* StartTime_ut */ time_start,
       /* StopTime_ut */ 0,
-      /* NumberOfNodes */ info.number_of_nodes,
       /* NumberOfEvents */ 0,
-      /* Fanout */ info.fanout,
       /* Exception */ "",
-      /* Config */ info.message.c_str());
+      /* Config */ info.message.c_str(),
+      /* Additonal */ info.additional_parameters.c_str());
   sqlite_helper_.execute(getInsertStatement(kGeneral, t));
 
   for (auto general_update : general_updates_) {

--- a/daisi/src/logging/logger_manager.h
+++ b/daisi/src/logging/logger_manager.h
@@ -37,9 +37,8 @@ class LoggerManager;
 inline std::unique_ptr<LoggerManager> global_logger_manager;
 
 struct LoggerInfoTestSetup {
-  uint64_t number_of_nodes;
-  uint32_t fanout;
   std::string message;
+  std::string additional_parameters;
 };
 
 class LoggerManager {

--- a/daisi/src/manager/manager.h
+++ b/daisi/src/manager/manager.h
@@ -123,19 +123,7 @@ public:
     using namespace ns3;
     scheduleEvents();
 
-    uint16_t max_size = 4023;
-    std::string content = parser_.getScenariofileContent();
-    if (content.size() > max_size) content.resize(max_size);
-
-    uint32_t fanout = 0;
-    try {
-      fanout = (uint32_t)parser_.getFanout();
-    } catch (const std::invalid_argument &e) {
-      fanout = 0;
-    }
-
-    daisi::LoggerInfoTestSetup info{this->getNumberOfNodes(), fanout,
-                                    parser_.getScenariofileContent()};
+    daisi::LoggerInfoTestSetup info{parser_.getScenariofileContent(), getAdditionalParameters()};
     daisi::global_logger_manager->logTestSetup(info);
 
     Simulator::Stop(MilliSeconds(parser_.getStopTime()));
@@ -290,6 +278,10 @@ protected:
   virtual void scheduleEvents() = 0;
   virtual uint64_t getNumberOfNodes() = 0;
   virtual std::string getDatabaseFilename() = 0;
+
+  // Return string with additional parameters of this simulation,
+  // that should be logged to the database
+  virtual std::string getAdditionalParameters() { return ""; }
 
   ScenariofileParser parser_;
 

--- a/daisi/src/minhton-ns3/minhton_manager.cpp
+++ b/daisi/src/minhton-ns3/minhton_manager.cpp
@@ -117,4 +117,8 @@ std::string MinhtonManager::getDatabaseFilename() {
   return generateDBNameWithMinhtonInfo("minhton", scenariofile_.fanout, this->getNumberOfNodes());
 }
 
+std::string MinhtonManager::getAdditionalParameters() {
+  return "NumberOfNodes=" + std::to_string(getNumberOfNodes());
+}
+
 }  // namespace daisi::minhton_ns3

--- a/daisi/src/minhton-ns3/minhton_manager.h
+++ b/daisi/src/minhton-ns3/minhton_manager.h
@@ -37,6 +37,7 @@ private:
   uint64_t getNumberOfNodes() override;
   void scheduleEvents() override;
   std::string getDatabaseFilename() override;
+  std::string getAdditionalParameters() override;
 
   std::shared_ptr<Scheduler> scheduler_;
   MinhtonScenariofile scenariofile_;

--- a/daisi/src/natter-ns3/natter_manager.cpp
+++ b/daisi/src/natter-ns3/natter_manager.cpp
@@ -252,4 +252,8 @@ std::string NatterManager::getDatabaseFilename() {
   return generateDBNameWithMinhtonInfo("natter", scenariofile_.fanout, getNumberOfNodes());
 }
 
+std::string NatterManager::getAdditionalParameters() {
+  return "NumberOfNodes=" + std::to_string(getNumberOfNodes());
+}
+
 }  // namespace daisi::natter_ns3

--- a/daisi/src/natter-ns3/natter_manager.h
+++ b/daisi/src/natter-ns3/natter_manager.h
@@ -46,6 +46,7 @@ private:
   void scheduleEvents() override;
   uint64_t getNumberOfNodes() override;
   std::string getDatabaseFilename() override;
+  std::string getAdditionalParameters() override;
 
   void scheduleEvent(const Join &step, uint64_t &current_time);
   void scheduleEvent(const Publish &step, uint64_t &current_time);

--- a/evaluation/minhton/model/general_db_information.py
+++ b/evaluation/minhton/model/general_db_information.py
@@ -4,6 +4,8 @@
 # For details on the licensing terms, see the LICENSE file.
 # SPDX-License-Identifier: MIT
 
+import re
+
 from utils.sqlite_db import SqliteDb
 
 class GeneralDbInformation():
@@ -20,15 +22,19 @@ class GeneralDbInformation():
 
     def get_network_size(self, db):
         statement = """
-        SELECT NumberOfNodes 
+        SELECT AdditionalParameters
         FROM General"""
-        return db.fetch_one(statement)[0]
+        res = db.fetch_one(statement)[0]
+        tokenized = res.split('=')
+        assert(tokenized[0] == "NumberOfNodes")
+        return int(res.split('=')[1])
 
     def get_fanout(self, db):
         statement = """
-        SELECT Fanout
+        SELECT Config
         FROM General"""
-        return db.fetch_one(statement)[0]
+        res = db.fetch_one(statement)[0]
+        return int(re.findall("(?<=fanout: )[0-9]*", res)[0])
 
     def get_max_height(self, db):
         statement = """

--- a/evaluation/natter/helper.py
+++ b/evaluation/natter/helper.py
@@ -8,8 +8,13 @@ from utils.sqlite_db import SqliteDb
 
 
 def get_node_count(db: SqliteDb):
-    return db.fetch_one("SELECT NumberOfNodes FROM General")[0]
-
+    statement = """
+    SELECT AdditionalParameters
+    FROM General"""
+    res = db.fetch_one(statement)[0]
+    tokenized = res.split('=')
+    assert(tokenized[0] == "NumberOfNodes")
+    return int(tokenized[1])
 
 def get_number_publish_events(db: SqliteDb):
     return db.fetch_one("SELECT COUNT(*) FROM Event WHERE Type=258")[0]


### PR DESCRIPTION
Fanout and NumberOfNodes are only relevant for MINHTON and natter. In these cases, the fanout is also available in the Content field. The NumberOfNodes field is now logged in a "AdditionalParameter" field.

Documentation is adapted on ``docs/daisi``.

# Definition of Done (optional)
- [x] Feature is implemented
- [x] No known bugs that stops the correct execution
- [x] CI / CD pipeline passed
- [x] The code guidelines were followed
- ~[ ] Unit and / or Integration tests for the new feature~
- [x] New feature was added to the documentation
