### PR TITLE
fix(optimaflow): Adapt metrics changes in Simple Order Management

### DIFF
--- a/.github/workflows/build-sola.yml
+++ b/.github/workflows/build-sola.yml
@@ -173,3 +173,11 @@ jobs:
         build/src/main/Main --environment=cpps --scenario=`pwd`/daisi/utils/ci_scenario_files/cpps_test.yml
         python3 evaluation/cpps_verification.py `find output -name '*.db'`
         rm -rf output
+    - name: Run ROUND_ROBIN integrationtest
+      run: |
+        export LD_LIBRARY_PATH=~/ns-3_install/lib
+        export MINHTONDIR=$GITHUB_WORKSPACE/minhton
+        mkdir output
+        export MINHTONDIR=`pwd`/minhton
+        build/src/main/Main --environment=cpps --scenario=`pwd`/daisi/utils/ci_scenario_files/round_robin_test.yml
+        rm -rf output

--- a/daisi/scenarios/cpps/default.yml
+++ b/daisi/scenarios/cpps/default.yml
@@ -26,9 +26,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: LoadRunner
-      friendly_name: LR
+      manufacturer: ManufacturerA
+      model_name: amr_fast_package
+      friendly_name: FPckg
       model_number: 1
     kinematics:
       min_velocity: 0.0
@@ -44,9 +44,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: LocusBot
-      model_name: LocusOrigin
-      friendly_name: locus
+      manufacturer: ManufacturerB
+      model_name: amr_slow_package
+      friendly_name: SPckg
       model_number: 2
     kinematics:
       min_velocity: 0.0
@@ -62,9 +62,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: ZTF
-      friendly_name: ztf
+      manufacturer: ManufacturerA
+      model_name: amr_weak_euro
+      friendly_name: WEuro
       model_number: 3
     kinematics:
       min_velocity: 0.0
@@ -80,9 +80,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: Flip
-      friendly_name: ctv
+      manufacturer: ManufacturerA
+      model_name: amr_strong_euro
+      friendly_name: SEuro
       model_number: 4
     kinematics:
       min_velocity: 0.0
@@ -103,28 +103,28 @@ material_flows:
 scenario_sequence:
   - amr:
     entity: amr
-    friendly_name: LR
+    friendly_name: FPckg
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: locus
+    friendly_name: SPckg
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: ztf
+    friendly_name: WEuro
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: ctv
+    friendly_name: SEuro
     start_time: 0
     spawn_distribution:
       type: absolute

--- a/daisi/src/cpps/logical/order_management/simple_order_management.cpp
+++ b/daisi/src/cpps/logical/order_management/simple_order_management.cpp
@@ -22,7 +22,9 @@ namespace daisi::cpps::logical {
 SimpleOrderManagement::SimpleOrderManagement(const AmrDescription &amr_description,
                                              const Topology &topology,
                                              const daisi::util::Pose &pose)
-    : OrderManagement(amr_description, topology, pose), expected_end_position_(pose.position) {}
+    : OrderManagement(amr_description, topology, pose), expected_end_position_(pose.position) {
+  final_metrics_.setStartTime(0);
+}
 
 Metrics SimpleOrderManagement::getFinalMetrics() const { return final_metrics_; }
 

--- a/daisi/utils/ci_scenario_files/cpps_test.yml
+++ b/daisi/utils/ci_scenario_files/cpps_test.yml
@@ -26,9 +26,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: LoadRunner
-      friendly_name: LR
+      manufacturer: ManufacturerA
+      model_name: amr_fast_package
+      friendly_name: FPckg
       model_number: 1
     kinematics:
       min_velocity: 0.0
@@ -44,9 +44,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: LocusBot
-      model_name: LocusOrigin
-      friendly_name: locus
+      manufacturer: ManufacturerB
+      model_name: amr_slow_package
+      friendly_name: SPckg
       model_number: 2
     kinematics:
       min_velocity: 0.0
@@ -62,9 +62,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: ZTF
-      friendly_name: ztf
+      manufacturer: ManufacturerA
+      model_name: amr_weak_euro
+      friendly_name: WEuro
       model_number: 3
     kinematics:
       min_velocity: 0.0
@@ -80,9 +80,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: Flip
-      friendly_name: ctv
+      manufacturer: ManufacturerA
+      model_name: amr_strong_euro
+      friendly_name: SEuro
       model_number: 4
     kinematics:
       min_velocity: 0.0
@@ -103,28 +103,28 @@ material_flows:
 scenario_sequence:
   - amr:
     entity: amr
-    friendly_name: LR
+    friendly_name: FPckg
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: locus
+    friendly_name: SPckg
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: ztf
+    friendly_name: WEuro
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: ctv
+    friendly_name: SEuro
     start_time: 0
     spawn_distribution:
       type: absolute

--- a/daisi/utils/ci_scenario_files/round_robin_test.yml
+++ b/daisi/utils/ci_scenario_files/round_robin_test.yml
@@ -26,9 +26,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: LoadRunner
-      friendly_name: LR
+      manufacturer: ManufacturerA
+      model_name: amr_fast_package
+      friendly_name: FPckg
       model_number: 1
     kinematics:
       min_velocity: 0.0
@@ -44,9 +44,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: LocusBot
-      model_name: LocusOrigin
-      friendly_name: locus
+      manufacturer: ManufacturerB
+      model_name: amr_slow_package
+      friendly_name: SPckg
       model_number: 2
     kinematics:
       min_velocity: 0.0
@@ -62,9 +62,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: ZTF
-      friendly_name: ztf
+      manufacturer: ManufacturerA
+      model_name: amr_weak_euro
+      friendly_name: WEuro
       model_number: 3
     kinematics:
       min_velocity: 0.0
@@ -80,9 +80,9 @@ autonomous_mobile_robots:
   - description:  
     properties:
       device_type: amr
-      manufacturer: FhG_IML
-      model_name: Flip
-      friendly_name: ctv
+      manufacturer: ManufacturerA
+      model_name: amr_strong_euro
+      friendly_name: SEuro
       model_number: 4
     kinematics:
       min_velocity: 0.0
@@ -103,28 +103,28 @@ material_flows:
 scenario_sequence:
   - amr:
     entity: amr
-    friendly_name: LR
+    friendly_name: FPckg
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: locus
+    friendly_name: SPckg
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: ztf
+    friendly_name: WEuro
     start_time: 0
     spawn_distribution:
       type: absolute
       number: 3
   - amr:
     entity: amr
-    friendly_name: ctv
+    friendly_name: SEuro
     start_time: 0
     spawn_distribution:
       type: absolute

--- a/daisi/utils/ci_scenario_files/round_robin_test.yml
+++ b/daisi/utils/ci_scenario_files/round_robin_test.yml
@@ -1,0 +1,139 @@
+title: CPPS Round Robin Scenario
+version: 0.1
+stop_time: 5000
+random_seed: 42
+default_delay: 5
+
+# outdated/unused fields
+# only present until Manager switches to new scenariofile parser as well
+randomSeed: 42
+stoptime: 5000000
+
+topology:
+    width:  50
+    height: 20
+    depth:   0
+
+initial_number_of_amrs: 12
+number_of_material_flows: 1
+number_of_material_flow_agents: 1
+do_material_flow_agents_leave_after_finish: false
+  
+algorithm:
+  assignment_strategy: round_robin
+
+autonomous_mobile_robots:
+  - description:  
+    properties:
+      device_type: amr
+      manufacturer: FhG_IML
+      model_name: LoadRunner
+      friendly_name: LR
+      model_number: 1
+    kinematics:
+      min_velocity: 0.0
+      max_velocity: 10.0
+      max_acceleration: 3.0
+      max_deceleration: 3.0
+    load_handling:
+      load_time: 2
+      unload_time: 3
+      load_carrier: package
+      max_payload: 30
+
+  - description:  
+    properties:
+      device_type: amr
+      manufacturer: LocusBot
+      model_name: LocusOrigin
+      friendly_name: locus
+      model_number: 2
+    kinematics:
+      min_velocity: 0.0
+      max_velocity: 1.1
+      max_acceleration: 0.5
+      max_deceleration: 0.5
+    load_handling:
+      load_time: 10
+      unload_time: 10
+      load_carrier: package
+      max_payload: 45
+
+  - description:  
+    properties:
+      device_type: amr
+      manufacturer: FhG_IML
+      model_name: ZTF
+      friendly_name: ztf
+      model_number: 3
+    kinematics:
+      min_velocity: 0.0
+      max_velocity: 1.0
+      max_acceleration: 0.5
+      max_deceleration: 0.5
+    load_handling:
+      load_time: 5
+      unload_time: 5
+      load_carrier: eurobox
+      max_payload: 30
+
+  - description:  
+    properties:
+      device_type: amr
+      manufacturer: FhG_IML
+      model_name: Flip
+      friendly_name: ctv
+      model_number: 4
+    kinematics:
+      min_velocity: 0.0
+      max_velocity: 1.0
+      max_acceleration: 0.5
+      max_deceleration: 0.5
+    load_handling:
+      load_time: 10
+      unload_time: 10
+      load_carrier: eurobox
+      max_payload: 60
+
+material_flows:
+  - mf:
+    mfdl_program: bli bla blub
+    friendly_name: mf1
+
+scenario_sequence:
+  - amr:
+    entity: amr
+    friendly_name: LR
+    start_time: 0
+    spawn_distribution:
+      type: absolute
+      number: 3
+  - amr:
+    entity: amr
+    friendly_name: locus
+    start_time: 0
+    spawn_distribution:
+      type: absolute
+      number: 3
+  - amr:
+    entity: amr
+    friendly_name: ztf
+    start_time: 0
+    spawn_distribution:
+      type: absolute
+      number: 3
+  - amr:
+    entity: amr
+    friendly_name: ctv
+    start_time: 0
+    spawn_distribution:
+      type: absolute
+      number: 3
+  - mf:
+    entity: mf
+    friendly_name: mf1
+    start_time: 0
+    spawn_distribution:
+      type: gaussian
+      mean: 100
+      sigma: 10


### PR DESCRIPTION
# Proposed Changes
Configures the `SimpleOrderManagement` to work with the newest changes in `Metrics` again.