### PR TITLE
Improve error handling and prevention + cleanup

### DIFF
--- a/daisi/src/logging/sqlite/sqlite_helper.cpp
+++ b/daisi/src/logging/sqlite/sqlite_helper.cpp
@@ -168,7 +168,7 @@ void SQLiteHelper::executeSql(const char *query) {
 
   if (rc != SQLITE_OK) {
     std::string error_message = "Error executing query: ";
-    error_message += err_msg_ptr;
+    error_message += err_msg_ptr + std::string(". Affected query: ") + query;
     //! In case of exception: Check query for broken strings
     throw std::runtime_error(error_message);
   }

--- a/daisi/src/manager/general_scenariofile.h
+++ b/daisi/src/manager/general_scenariofile.h
@@ -66,7 +66,7 @@ struct GeneralScenariofile {
   std::string version;
 
   // setup information
-  int random_seed = 0;
+  uint64_t random_seed = 0;
 
   // simulation information
   uint64_t stop_time = 0;

--- a/daisi/src/minhton-ns3/minhton_manager_scheduler.h
+++ b/daisi/src/minhton-ns3/minhton_manager_scheduler.h
@@ -38,18 +38,18 @@ private:
   void setupRequestingNodes();
   void setupRootBehavior();
 
-  void executeOneJoinByPosition(uint16_t level, uint16_t number);
+  void executeOneJoinByPosition(uint32_t level, uint32_t number);
   void executeOneJoinByIndex(uint16_t index);
   void executeOneJoinOnRoot();
   void executeOneRandomJoin();
   void executeOneJoinDiscover();
 
-  void executeOneLeaveByPosition(uint16_t level, uint16_t number);
+  void executeOneLeaveByPosition(uint32_t level, uint32_t number);
   void executeOneLeaveByIndex(uint16_t index);
   void executeOneLeaveOnRoot();
   void executeOneRandomLeave();
 
-  void executeOneFailByPosition(uint16_t level, uint16_t number);
+  void executeOneFailByPosition(uint32_t level, uint32_t number);
   void executeOneFailByIndex(uint16_t index);
   void executeOneRandomFail();
 
@@ -59,7 +59,7 @@ private:
   void initiateFailureNow(uint64_t node_to_fail_to_index);
 
   void scheduleSearchExactAll(uint64_t delay);
-  void scheduleSearchExactMany(uint64_t delay, uint16_t number);
+  void scheduleSearchExactMany(uint64_t delay, uint32_t number);
   void executeOneSearchExact(ns3::Ptr<MinhtonApplication> src_app, uint32_t dest_level,
                              uint32_t dest_number);
   void executeOneRandomSearchExact();
@@ -74,7 +74,7 @@ private:
   std::vector<uint64_t> getInitializedNodeIndexes();
   std::tuple<std::vector<uint64_t>, std::vector<std::tuple<uint16_t, uint16_t>>>
   getExistingPositions();
-  ns3::Ptr<MinhtonApplication> getApplicationAtPosition(uint16_t level, uint16_t number);
+  ns3::Ptr<MinhtonApplication> getApplicationAtPosition(uint32_t level, uint32_t number);
 
   std::deque<uint64_t> uninit_index_deque_;
   std::deque<uint64_t> init_index_deque_;

--- a/daisi/src/minhton-ns3/minhton_manager_scheduler_helper.cpp
+++ b/daisi/src/minhton-ns3/minhton_manager_scheduler_helper.cpp
@@ -100,7 +100,7 @@ void MinhtonManager::Scheduler::scheduleMixedExecution(uint64_t join_num, uint64
   }
 }
 
-void MinhtonManager::Scheduler::executeOneJoinByPosition(uint16_t level, uint16_t number) {
+void MinhtonManager::Scheduler::executeOneJoinByPosition(uint32_t level, uint32_t number) {
   std::cout << "\texecuteOneJoinByPosition on (" << level << ":" << number << ") at "
             << Simulator::Now().GetMilliSeconds() << std::endl;
 
@@ -233,7 +233,7 @@ void MinhtonManager::Scheduler::initiateJoinNow(uint64_t node_to_join_to_index,
   initiatePeerDiscoverEnvironmentAfterJoin(entering_app);
 }
 
-void MinhtonManager::Scheduler::executeOneLeaveByPosition(uint16_t level, uint16_t number) {
+void MinhtonManager::Scheduler::executeOneLeaveByPosition(uint32_t level, uint32_t number) {
   std::cout << "\texecuteOneLeaveByPosition on (" << level << ":" << number << ") at "
             << Simulator::Now().GetMilliSeconds() << std::endl;
 
@@ -358,7 +358,7 @@ void MinhtonManager::Scheduler::scheduleSearchExactAll(uint64_t delay) {
   }
 }
 
-void MinhtonManager::Scheduler::scheduleSearchExactMany(uint64_t delay, uint16_t number) {
+void MinhtonManager::Scheduler::scheduleSearchExactMany(uint64_t delay, uint32_t number) {
   uint64_t current_delay = 0;
 
   auto existing_positions_tuple = this->getExistingPositions();
@@ -422,7 +422,7 @@ void MinhtonManager::Scheduler::executeOneRandomSearchExact() {
   app_1->executeSearchExactTest(node_info_2.getLevel(), node_info_2.getNumber());
 }
 
-void MinhtonManager::Scheduler::executeOneFailByPosition(uint16_t level, uint16_t number) {
+void MinhtonManager::Scheduler::executeOneFailByPosition(uint32_t level, uint32_t number) {
   std::cout << "\texecuteOneFailByPosition on (" << level << ":" << number << ") at "
             << Simulator::Now().GetMilliSeconds() << std::endl;
 
@@ -549,8 +549,8 @@ MinhtonManager::Scheduler::getExistingPositions() {
   return std::make_tuple(indices, positions);
 }
 
-Ptr<MinhtonApplication> MinhtonManager::Scheduler::getApplicationAtPosition(uint16_t level,
-                                                                            uint16_t number) {
+Ptr<MinhtonApplication> MinhtonManager::Scheduler::getApplicationAtPosition(uint32_t level,
+                                                                            uint32_t number) {
   for (uint64_t i = 0; i < manager_.getNumberOfNodes(); i++) {
     auto app = manager_.node_container_.Get(i)->GetApplication(0)->GetObject<MinhtonApplication>();
     minhton::NodeInfo node_info = app->getNodeInfo();

--- a/daisi/src/minhton-ns3/minhton_manager_scheduler_helper.cpp
+++ b/daisi/src/minhton-ns3/minhton_manager_scheduler_helper.cpp
@@ -246,12 +246,11 @@ void MinhtonManager::Scheduler::executeOneLeaveByPosition(uint16_t level, uint16
       if (app->getNodeInfo().isInitialized()) {
         this->initiateLeaveNow(leave_index);
 
-        for (auto it = this->init_index_deque_.begin(); it != this->init_index_deque_.end(); it++) {
-          if (leave_index == *it) {
-            this->init_index_deque_.erase(it);
-            break;
-          }
+        const auto it = std::find(init_index_deque_.begin(), init_index_deque_.end(), leave_index);
+        if (it == this->init_index_deque_.end()) {
+          throw std::invalid_argument("Index to leave not found in init_index_deque_");
         }
+        this->init_index_deque_.erase(it);
         this->uninit_index_deque_.push_back(leave_index);
         return;
       }
@@ -274,12 +273,12 @@ void MinhtonManager::Scheduler::executeOneLeaveByIndex(uint16_t index) {
 
   if (app->getNodeInfo().isInitialized()) {
     this->initiateLeaveNow(index);
-    for (auto it = this->init_index_deque_.begin(); it != this->init_index_deque_.end(); it++) {
-      if (index == *it) {
-        this->init_index_deque_.erase(it);
-        break;
-      }
+
+    const auto it = std::find(init_index_deque_.begin(), init_index_deque_.end(), index);
+    if (it == this->init_index_deque_.end()) {
+      throw std::invalid_argument("Index to leave not found in init_index_deque_");
     }
+    this->init_index_deque_.erase(it);
     this->uninit_index_deque_.push_back(index);
   } else {
     std::cout << "node to leave found but is not initialized";
@@ -300,12 +299,9 @@ void MinhtonManager::Scheduler::executeOneRandomLeave() {
             << std::endl;
   this->initiateLeaveNow(random_index_to_leave);
 
-  for (auto it = this->init_index_deque_.begin(); it != this->init_index_deque_.end(); it++) {
-    if (random_index_to_leave == *it) {
-      this->init_index_deque_.erase(it);
-      break;
-    }
-  }
+  const auto it =
+      std::find(init_index_deque_.begin(), init_index_deque_.end(), random_index_to_leave);
+  this->init_index_deque_.erase(it);
   this->uninit_index_deque_.push_back(random_index_to_leave);
 }
 
@@ -316,12 +312,8 @@ void MinhtonManager::Scheduler::executeOneLeaveOnRoot() {
   this->initiateLeaveNow(root_index);
 
   // finding root_index in deque and erasing
-  for (auto it = this->init_index_deque_.begin(); it != this->init_index_deque_.end(); it++) {
-    if (root_index == *it) {
-      this->init_index_deque_.erase(it);
-      break;
-    }
-  }
+  const auto it = std::find(init_index_deque_.begin(), init_index_deque_.end(), root_index);
+  this->init_index_deque_.erase(it);
   this->uninit_index_deque_.push_back(root_index);
 }
 
@@ -443,12 +435,11 @@ void MinhtonManager::Scheduler::executeOneFailByPosition(uint16_t level, uint16_
       if (app->getNodeInfo().isInitialized()) {
         this->initiateFailureNow(fail_index);
 
-        for (auto it = this->init_index_deque_.begin(); it != this->init_index_deque_.end(); it++) {
-          if (fail_index == *it) {
-            this->init_index_deque_.erase(it);
-            break;
-          }
+        const auto it = std::find(init_index_deque_.begin(), init_index_deque_.end(), fail_index);
+        if (it == this->init_index_deque_.end()) {
+          throw std::invalid_argument("Index to fail not found in init_index_deque_");
         }
+        this->init_index_deque_.erase(it);
         this->uninit_index_deque_.push_back(fail_index);
         return;
       }
@@ -471,12 +462,12 @@ void MinhtonManager::Scheduler::executeOneFailByIndex(uint16_t index) {
 
   if (app->getNodeInfo().isInitialized()) {
     this->initiateFailureNow(index);
-    for (auto it = this->init_index_deque_.begin(); it != this->init_index_deque_.end(); it++) {
-      if (index == *it) {
-        this->init_index_deque_.erase(it);
-        break;
-      }
+
+    const auto it = std::find(init_index_deque_.begin(), init_index_deque_.end(), index);
+    if (it == this->init_index_deque_.end()) {
+      throw std::invalid_argument("Index to fail not found in init_index_deque_");
     }
+    this->init_index_deque_.erase(it);
     this->uninit_index_deque_.push_back(index);
   } else {
     std::cout << "node to fail found but is not initialized";

--- a/daisi/src/natter-ns3/natter_manager.cpp
+++ b/daisi/src/natter-ns3/natter_manager.cpp
@@ -48,7 +48,7 @@ ns3::Ptr<NatterApplication> NatterManager::getApplication(uint32_t id) const {
 }
 
 NatterManager::NodeInfo NatterManager::getNodeInfo(uint32_t index) {
-  uint64_t fanout = scenariofile_.fanout;
+  uint16_t fanout = scenariofile_.fanout;
   const uint32_t own_level = natter_ns3::calculateLevel(index, fanout);
   const uint32_t own_number = natter_ns3::calculateNumber(index, fanout, own_level);
   const ns3::Ptr<NatterApplication> app = getApplication(index);
@@ -88,7 +88,7 @@ std::set<uint32_t> NatterManager::connectChildren(const NodeInfo &info) {
 std::set<uint32_t> NatterManager::connectNeighbors(const NodeInfo &info) {
   std::set<uint32_t> neighbors;
 
-  auto get_neighbor_distance = [](const uint32_t d, const uint64_t fanout,
+  auto get_neighbor_distance = [](const uint32_t d, const uint16_t fanout,
                                   const uint32_t i) -> uint32_t {
     return d * static_cast<uint32_t>(std::pow(fanout, i));  // [BATON* - Jagadish]
   };

--- a/daisi/src/natter-ns3/natter_manager.h
+++ b/daisi/src/natter-ns3/natter_manager.h
@@ -33,7 +33,7 @@ public:
 
 private:
   struct NodeInfo {
-    const uint64_t fanout;
+    const uint16_t fanout;
     const solanet::UUID own_uuid;
     const std::string ip;
     const uint16_t port;

--- a/daisi/src/natter-ns3/static_network_calculation.cpp
+++ b/daisi/src/natter-ns3/static_network_calculation.cpp
@@ -19,7 +19,7 @@
 #include <cmath>
 
 namespace daisi::natter_ns3 {
-uint32_t calculateLevel(uint32_t node_id, uint32_t fanout) {
+uint32_t calculateLevel(uint32_t node_id, uint16_t fanout) {
   uint32_t level = 0;
   while (node_id != 0) {
     node_id = std::ceil(node_id / (float)fanout) - 1;
@@ -28,13 +28,13 @@ uint32_t calculateLevel(uint32_t node_id, uint32_t fanout) {
   return level;
 }
 
-uint32_t calculateNumber(uint32_t i, uint32_t fanout, uint32_t own_level) {
+uint32_t calculateNumber(uint32_t i, uint16_t fanout, uint32_t own_level) {
   if (own_level == 0) return 0;
   uint32_t nodes_above = (pow(fanout, own_level) - 1) / (fanout - 1);
   return i - nodes_above;
 }
 
-std::vector<uint32_t> createLinearProjection(uint64_t number_of_nodes, uint32_t fanout,
+std::vector<uint32_t> createLinearProjection(uint64_t number_of_nodes, uint16_t fanout,
                                              uint32_t own_index) {
   uint32_t i = 1;
   std::vector<uint32_t> proj{};

--- a/daisi/src/natter-ns3/static_network_calculation.h
+++ b/daisi/src/natter-ns3/static_network_calculation.h
@@ -21,9 +21,9 @@
 #include <vector>
 
 namespace daisi::natter_ns3 {
-uint32_t calculateLevel(uint32_t node_id, uint32_t fanout);
-uint32_t calculateNumber(uint32_t i, uint32_t fanout, uint32_t own_level);
-std::vector<uint32_t> createLinearProjection(uint64_t number_of_nodes, uint32_t fanout,
+uint32_t calculateLevel(uint32_t node_id, uint16_t fanout);
+uint32_t calculateNumber(uint32_t i, uint16_t fanout, uint32_t own_level);
+std::vector<uint32_t> createLinearProjection(uint64_t number_of_nodes, uint16_t fanout,
                                              uint32_t own_index);
 }  // namespace daisi::natter_ns3
 

--- a/daisi/src/path_planning/consensus/central/message/request.h
+++ b/daisi/src/path_planning/consensus/central/message/request.h
@@ -26,7 +26,7 @@
 namespace daisi::path_planning::consensus {
 //! Request message from a pickup station to the central server
 struct Request {
-  SERIALIZE(request_id, earliest_possible_start_ms, intersection_times);
+  SERIALIZE(request_id, earliest_possible_start_ms, intersection_times)
   uint32_t request_id;  //!< Per station unique request id to match requests and responses
   uint64_t earliest_possible_start_ms;  //!< Earliest possible time at which the AGV can start
   std::vector<std::tuple<float, float, double>>

--- a/daisi/src/path_planning/consensus/central/message/response.h
+++ b/daisi/src/path_planning/consensus/central/message/response.h
@@ -26,7 +26,7 @@
 namespace daisi::path_planning::consensus {
 //! Response to a request from central server to pickup station
 struct Response {
-  SERIALIZE(success, request_id, start_offset);
+  SERIALIZE(success, request_id, start_offset)
   uint32_t request_id;  //!< Per station unique request id to match requests and responses
   bool success;         //!< True if request was successful. If false, \p start_offset_ is not valid
   double start_offset;  //!< Global possible start time in seconds

--- a/daisi/src/path_planning/consensus/paxos/message/accept_message.h
+++ b/daisi/src/path_planning/consensus/paxos/message/accept_message.h
@@ -27,7 +27,7 @@ namespace daisi::path_planning::consensus {
 //!< Accept message send from the proposer to the acceptors with the actual intersection
 //!< occupancies that should be set for the given instance
 struct AcceptMessage {
-  SERIALIZE(instance_id, proposal_id, station_id, intersections);
+  SERIALIZE(instance_id, proposal_id, station_id, intersections)
 
   uint32_t instance_id = 0;
   uint32_t proposal_id = 0;

--- a/daisi/src/path_planning/consensus/paxos/message/ok_message.h
+++ b/daisi/src/path_planning/consensus/paxos/message/ok_message.h
@@ -24,7 +24,7 @@
 namespace daisi::path_planning::consensus {
 //!< OK message from all acceptors to all other participants to commit the requested occupancy
 struct OKMessage {
-  SERIALIZE(instance_id, station_id, proposal_id, sender_station);
+  SERIALIZE(instance_id, station_id, proposal_id, sender_station)
   uint32_t instance_id = 0;
   uint32_t proposal_id = 0;
   uint32_t station_id = 0;

--- a/daisi/src/path_planning/consensus/paxos/message/prepare_message.h
+++ b/daisi/src/path_planning/consensus/paxos/message/prepare_message.h
@@ -28,7 +28,7 @@ namespace daisi::path_planning::consensus {
 //!< Prepare message send from proposer to all acceptors which is used to get a promise from
 //!< all acceptors (quorum) so that they will accept the occupancies.
 struct PrepareMessage {
-  SERIALIZE(instance_id, prepare_id, station_id);
+  SERIALIZE(instance_id, prepare_id, station_id)
 
   uint32_t instance_id = 0;
   uint32_t prepare_id = 0;

--- a/daisi/src/path_planning/consensus/paxos/message/promise_message.h
+++ b/daisi/src/path_planning/consensus/paxos/message/promise_message.h
@@ -28,7 +28,7 @@ namespace daisi::path_planning::consensus {
 //!< acceptors).
 struct PromiseMessage {
   SERIALIZE(instance_id, prepare_id, station_id, already_accepted, accepted_prepare_id,
-            accepted_station_id);
+            accepted_station_id)
   uint32_t instance_id = 0;
   uint32_t prepare_id = 0;
   uint32_t station_id = 0;

--- a/daisi/src/path_planning/consensus/paxos/message/replication_message.h
+++ b/daisi/src/path_planning/consensus/paxos/message/replication_message.h
@@ -26,7 +26,7 @@ namespace daisi::path_planning::consensus {
 //!< participants know about this consensus
 //!< Possible to add other data, e.g., billing relevant data
 struct ReplicationMessage {
-  SERIALIZE(instance_id, station_id, proposal_id);
+  SERIALIZE(instance_id, station_id, proposal_id)
   uint32_t instance_id = 0;
   uint32_t proposal_id = 0;
   uint32_t station_id = 0;

--- a/daisi/src/path_planning/consensus/paxos/message/response_message.h
+++ b/daisi/src/path_planning/consensus/paxos/message/response_message.h
@@ -25,7 +25,7 @@ namespace daisi::path_planning::consensus {
 //!< Response message send from acceptors to proposer to acknowledge that the acceptor received an
 //!< OK from all other acceptors and therefore committed the wanted occupancy to its local data
 struct ResponseMessage {
-  SERIALIZE(instance_id, station_id, proposal_id);
+  SERIALIZE(instance_id, station_id, proposal_id)
   uint32_t instance_id = 0;
   uint32_t proposal_id = 0;
   uint32_t station_id = 0;

--- a/daisi/src/path_planning/message/drive_message.h
+++ b/daisi/src/path_planning/message/drive_message.h
@@ -37,7 +37,7 @@ public:
 
   [[nodiscard]] ns3::Vector2D getGoal() const { return {pos_x_, pos_y_}; };
 
-  SERIALIZE(pos_x_, pos_y_);
+  SERIALIZE(pos_x_, pos_y_)
 
 private:
   bool initialized_ = false;

--- a/daisi/src/path_planning/message/field/drive_message_field.h
+++ b/daisi/src/path_planning/message/field/drive_message_field.h
@@ -22,7 +22,7 @@
 namespace daisi::path_planning::message {
 //! Message send from \c AGVLogical to \c AGVPhysicalBasic with a 2D coordinate.
 struct DriveMessageField {
-  SERIALIZE(x, y);
+  SERIALIZE(x, y)
   double x;
   double y;
 };

--- a/daisi/src/path_planning/message/field/position_update.h
+++ b/daisi/src/path_planning/message/field/position_update.h
@@ -23,7 +23,7 @@ namespace daisi::path_planning::message {
 //! Update of the actual AGV position send from \c AGVPhysicalBasic to \c AGVLogical
 class PositionUpdate {
 public:
-  SERIALIZE(x, y, z);
+  SERIALIZE(x, y, z)
   double x;
   double y;
   double z;

--- a/daisi/src/path_planning/message/handover_message.h
+++ b/daisi/src/path_planning/message/handover_message.h
@@ -37,7 +37,7 @@ public:
   [[nodiscard]] std::string getNextStationIP() const { return next_station_ip_; }
   [[nodiscard]] DriveMessage getDriveMessage() const { return drive_; }
 
-  SERIALIZE(drive_, next_station_, next_station_ip_);
+  SERIALIZE(drive_, next_station_, next_station_ip_)
 
 private:
   DriveMessage drive_;

--- a/daisi/src/path_planning/message/misc/new_authority_agv.h
+++ b/daisi/src/path_planning/message/misc/new_authority_agv.h
@@ -28,7 +28,7 @@ class NewAuthorityAGV {
 public:
   SERIALIZE(agv_ip, agv_uuid, min_acceleration, max_acceleration, min_velocity, max_velocity,
             load_time_s, unload_time_s, current_x, current_y, initial, current_del_dest_x,
-            current_del_dest_y);
+            current_del_dest_y)
 
   std::string agv_ip;
   std::string agv_uuid;

--- a/daisi/src/path_planning/message/misc/reached_goal.h
+++ b/daisi/src/path_planning/message/misc/reached_goal.h
@@ -25,7 +25,7 @@ namespace daisi::path_planning::message {
 //! Message that \c AGVLogical sends to inform \c PickupStation that previous goal from \c
 //! DriveMessage has been reached.
 struct ReachedGoal {
-  SERIALIZE(agv_uuid, x, y);
+  SERIALIZE(agv_uuid, x, y)
   std::string agv_uuid;
   double x;
   double y;

--- a/daisi/src/path_planning/task.h
+++ b/daisi/src/path_planning/task.h
@@ -52,7 +52,7 @@ public:
   void setName(const std::string &name);
   std::string getName() const;
 
-  SERIALIZE(uuid_, from_x_, from_y_, to_x_, to_y_, connection_, name_);
+  SERIALIZE(uuid_, from_x_, from_y_, to_x_, to_y_, connection_, name_)
 
 private:
   std::string uuid_;

--- a/minhton/include/minhton/algorithms/find_end/minhton_find_end_algorithm.h
+++ b/minhton/include/minhton/algorithms/find_end/minhton_find_end_algorithm.h
@@ -14,7 +14,6 @@
 #include "minhton/message/types_all.h"
 
 namespace minhton {
-#define MAX_HOP_COUNT 64U
 
 class MinhtonFindEndAlgorithm : public AlgorithmInterface {
 public:
@@ -23,19 +22,21 @@ public:
 
   void process(const MessageVariant &) override {}
 
-  /// Helper method to send a message for forwarding the join / Leave request to another node
+  /// Helper method to send a message for forwarding the join / leave request to another node
   ///
   /// \param target Node to forward the join / leave request to
   /// \param request_origin The node which wishes to join / leave the network
   /// \param search_progress The current step of the join / leave algorithm
+  /// \param hop_count Counter for how many times the request has been forwarded
   void forwardRequest(minhton::NodeInfo target, minhton::NodeInfo request_origin,
-                      SearchProgress search_progress);
+                      SearchProgress search_progress, uint16_t hop_count);
 
   /// Helper method to jump to the most beneficial adjacent node (during a join / leave)
   ///
   /// \param request_origin The new node that wants to join or the existing node that wants to leave
   /// the network.
-  void forwardToAdjacentNode(minhton::NodeInfo request_origin);
+  /// \param hop_count Counter for how many times the request has been forwarded
+  void forwardToAdjacentNode(minhton::NodeInfo request_origin, uint16_t hop_count);
 
   /// Helper method to check if the current node is the wanted join / leave replacement node
   /// position. Only use after it is known which level is the last one!
@@ -48,7 +49,8 @@ public:
   /// \param request_origin The new node that wants to join or the existing node that wants to leave
   /// the network.
   /// \param left_side Set to true to only search on the left side, else on the right side
-  void searchEndOnLevel(minhton::NodeInfo request_origin, bool left_side);
+  /// \param hop_count Counter for how many times the request has been forwarded
+  void searchEndOnLevel(minhton::NodeInfo request_origin, bool left_side, uint16_t hop_count);
 
   /// Helper method to get a node which is either the direct parent of a node or somewhere close to
   /// where the actual parent is, if the parent isn't in the routing table
@@ -61,7 +63,8 @@ public:
   ///
   /// \param request_origin The new node that wants to join or the existing node that wants to leave
   /// the network.
-  void checkRight(minhton::NodeInfo request_origin);
+  /// \param hop_count Counter for how many times the request has been forwarded
+  void checkRight(minhton::NodeInfo request_origin, uint16_t hop_count);
 
   /// Helper method to check if the passed node is the last one that can exists on a level and is
   /// initialized
@@ -76,19 +79,13 @@ public:
   /// \param request_origin The new node that wants to join or the existing node that wants to leave
   /// the network.
   /// \returns true when found correct position, false when concurrent steps are needed
-  bool decideNextStep(minhton::NodeInfo request_origin);
-
-  void setHopCount(uint16_t hop_count);
-
-  void resetHopCount();
+  /// \param hop_count Counter for how many times the request has been forwarded
+  bool decideNextStep(minhton::NodeInfo request_origin, uint16_t hop_count);
 
 private:
   /// Set to true if the Find End Algorithm should operate in the mode for the join procedure, or
   /// set to false for usage with the leave procedure
   bool join_;
-
-  /// How often message for finding the position has been sent during this procedure so far
-  uint16_t hop_count_ = 0;
 };
 
 }  // namespace minhton

--- a/minhton/include/minhton/algorithms/find_end/minhton_find_end_algorithm.h
+++ b/minhton/include/minhton/algorithms/find_end/minhton_find_end_algorithm.h
@@ -14,6 +14,7 @@
 #include "minhton/message/types_all.h"
 
 namespace minhton {
+#define MAX_HOP_COUNT 64U
 
 class MinhtonFindEndAlgorithm : public AlgorithmInterface {
 public:
@@ -77,10 +78,17 @@ public:
   /// \returns true when found correct position, false when concurrent steps are needed
   bool decideNextStep(minhton::NodeInfo request_origin);
 
+  void setHopCount(uint16_t hop_count);
+
+  void resetHopCount();
+
 private:
   /// Set to true if the Find End Algorithm should operate in the mode for the join procedure, or
   /// set to false for usage with the leave procedure
   bool join_;
+
+  /// How often message for finding the position has been sent during this procedure so far
+  uint16_t hop_count_ = 0;
 };
 
 }  // namespace minhton

--- a/minhton/include/minhton/algorithms/leave/leave_algorithm_general.h
+++ b/minhton/include/minhton/algorithms/leave/leave_algorithm_general.h
@@ -204,17 +204,6 @@ protected:
   /// \param node_to_replace The node leaving the network
   void prepareLeavingAsSuccessor(const minhton::NodeInfo &node_to_replace);
 
-  /// Helper method for the Leave Algorithm to quickly forward the FIND_REPLACEMENT message to the
-  /// target node.
-  ///
-  /// \param forward_to the node we want to forward the message to
-  /// \param node_to_replace the node which wants to leave the network
-  /// \param leave_case the current step
-  /// of the find replacement algorithm (optional)
-  void forwardFindReplacementMessage(minhton::NodeInfo forward_to,
-                                     minhton::NodeInfo node_to_replace,
-                                     SearchProgress leave_case = SearchProgress::kNone);
-
   /// Send a MessageSignoffParentRequest to own parent.
   /// This helper method can be called from the successor or the leaving node itself if it doesn't
   /// need a successor.

--- a/minhton/include/minhton/core/node.h
+++ b/minhton/include/minhton/core/node.h
@@ -145,7 +145,9 @@ private:
   /// divergent FSM event.
   ///
   /// \param msg_variant Message to check
-  void prepareReceiving(const MessageVariant &msg_variant);
+  ///
+  /// \returns true if the message should be processed, false if not
+  bool prepareReceiving(const MessageVariant &msg_variant);
 
   /// After all relevant information have been set, we can start the node.
   ///

--- a/minhton/include/minhton/core/routing_calculations.h
+++ b/minhton/include/minhton/core/routing_calculations.h
@@ -194,7 +194,7 @@ bool isFanoutValid(uint16_t fanout);
 ///
 /// \returns horizontal value
 ///
-double treeMapper(uint16_t level, uint16_t number, uint8_t fanout, double K);
+double treeMapper(uint32_t level, uint32_t number, uint16_t fanout, double K);
 
 ///
 /// Method internally used by the treeMapper to additionally pass lower and upper bounds.
@@ -202,8 +202,8 @@ double treeMapper(uint16_t level, uint16_t number, uint8_t fanout, double K);
 ///
 /// \returns tuple of lower bound, upper bound, and center
 ///
-std::tuple<double, double, double> treeMapperInternal(uint16_t level, uint16_t number,
-                                                      uint8_t fanout, uint8_t K);
+std::tuple<double, double, double> treeMapperInternal(uint32_t level, uint32_t number,
+                                                      uint16_t fanout, uint8_t K);
 
 std::tuple<uint32_t, uint32_t> getCoveringDSN(uint32_t level, uint32_t number, uint16_t fanout);
 std::vector<std::tuple<uint32_t, uint32_t>> getCoverArea(uint32_t level, uint32_t number,

--- a/minhton/include/minhton/logging/logger_interface.h
+++ b/minhton/include/minhton/logging/logger_interface.h
@@ -31,7 +31,7 @@ struct LoggerInfoAddNode {
   std::string position_uuid;
   uint32_t level;
   uint32_t number;
-  uint32_t fanout;
+  uint16_t fanout;
   bool initialized;
 };
 

--- a/minhton/include/minhton/message/find_replacement.h
+++ b/minhton/include/minhton/message/find_replacement.h
@@ -32,7 +32,7 @@ public:
   SearchProgress getSearchProgress() const;
   uint16_t getHopCount() const;
 
-  SERIALIZE(header_, node_to_replace_, search_progress_, hop_count_);
+  SERIALIZE(header_, node_to_replace_, search_progress_, hop_count_)
 
   MessageFindReplacement() = default;
 

--- a/minhton/include/minhton/message/find_replacement.h
+++ b/minhton/include/minhton/message/find_replacement.h
@@ -22,13 +22,17 @@ class MessageFindReplacement : public MinhtonMessage<MessageFindReplacement> {
 public:
   /// @param node_to_replace The node that wants to leave the network.
   /// @param search_progress Represents the procedure progress for differentiating the phases.
+  /// @param hop_count How often a MessageFindReplacement has been sent during this leave
+  /// procedure so far.
   MessageFindReplacement(MinhtonMessageHeader header, NodeInfo node_to_replace,
-                         SearchProgress search_progress = SearchProgress::kNone);
+                         SearchProgress search_progress = SearchProgress::kNone,
+                         uint16_t hop_count = 0);
 
   NodeInfo getNodeToReplace() const;
   SearchProgress getSearchProgress() const;
+  uint16_t getHopCount() const;
 
-  SERIALIZE(header_, node_to_replace_, search_progress_)
+  SERIALIZE(header_, node_to_replace_, search_progress_, hop_count_);
 
   MessageFindReplacement() = default;
 
@@ -47,6 +51,10 @@ private:
 
   /// Stores information about what steps were already done
   SearchProgress search_progress_ = SearchProgress::kNone;
+
+  /// Keeps track of how many times a MessageFindReplacement has been sent during this leave
+  /// procedure
+  uint16_t hop_count_ = 0;
 };
 }  // namespace minhton
 

--- a/minhton/include/minhton/message/join.h
+++ b/minhton/include/minhton/message/join.h
@@ -25,7 +25,7 @@ public:
   SearchProgress getSearchProgress() const;
   uint16_t getHopCount() const;
 
-  SERIALIZE(header_, entering_node_, search_progress_, hop_count_);
+  SERIALIZE(header_, entering_node_, search_progress_, hop_count_)
 
   MessageJoin() = default;
 

--- a/minhton/include/minhton/message/join.h
+++ b/minhton/include/minhton/message/join.h
@@ -18,16 +18,14 @@ namespace minhton {
 /// * **Algorithm Association:** Join.
 class MessageJoin : public MinhtonMessage<MessageJoin> {
 public:
-  /// @param entering_node The node that wants to enter the network. NetworkInfo must be set
-  /// appropriately.
-  /// @param search_progress Represents the procedure progress for differentiating the phases.
   MessageJoin(MinhtonMessageHeader header, NodeInfo entering_node,
-              SearchProgress search_progress = SearchProgress::kNone);
+              SearchProgress search_progress = SearchProgress::kNone, uint16_t hop_count = 0);
 
   NodeInfo getEnteringNode() const;
   SearchProgress getSearchProgress() const;
+  uint16_t getHopCount() const;
 
-  SERIALIZE(header_, entering_node_, search_progress_)
+  SERIALIZE(header_, entering_node_, search_progress_, hop_count_);
 
   MessageJoin() = default;
 
@@ -46,6 +44,9 @@ private:
 
   /// Stores information about what steps were already done (only for the minhton algorithm)
   SearchProgress search_progress_ = SearchProgress::kNone;
+
+  /// Keeps track of how many times a MessageJoin has been sent during this join procedure
+  uint16_t hop_count_ = 0;
 };
 }  // namespace minhton
 

--- a/minhton/src/algorithms/join/join_algorithm_general_helper.cpp
+++ b/minhton/src/algorithms/join/join_algorithm_general_helper.cpp
@@ -29,7 +29,7 @@ minhton::NodeInfo JoinAlgorithmGeneral::calcNewChildPosition(bool use_complete_b
     for (uint16_t i = 0; i < getRoutingInfo()->getFanout(); i++) {
       // look at each free position
       if (!getRoutingInfo()->getChildren()[i].isInitialized()) {
-        uint16_t current_num = getSelfNodeInfo().getNumber() * getRoutingInfo()->getFanout() + i;
+        uint32_t current_num = getSelfNodeInfo().getNumber() * getRoutingInfo()->getFanout() + i;
         minhton::NodeInfo new_child =
             NodeInfo(getSelfNodeInfo().getLevel() + 1, current_num, getRoutingInfo()->getFanout());
         return new_child;
@@ -45,7 +45,7 @@ minhton::NodeInfo JoinAlgorithmGeneral::calcNewChildPosition(bool use_complete_b
   for (uint16_t i = 0; i < getRoutingInfo()->getFanout(); i++) {
     // look at each free position
     if (!getRoutingInfo()->getChildren()[i].isInitialized()) {
-      uint16_t current_num = getSelfNodeInfo().getNumber() * getRoutingInfo()->getFanout() + i;
+      uint32_t current_num = getSelfNodeInfo().getNumber() * getRoutingInfo()->getFanout() + i;
       double current_value = treeMapper(getSelfNodeInfo().getLevel() + 1, current_num,
                                         getRoutingInfo()->getFanout(), k_TREEMAPPER_ROOT_VALUE);
       double current_diff = std::abs(root_value - current_value);

--- a/minhton/src/algorithms/join/minhton_join_algorithm.cpp
+++ b/minhton/src/algorithms/join/minhton_join_algorithm.cpp
@@ -26,7 +26,6 @@ void MinhtonJoinAlgorithm::processJoin(const MessageJoin &msg) {
     access_->procedure_info->saveEventId(ProcedureKey::kJoinProcedure,
                                          msg.getHeader().getRefEventId());
   }
-  find_end_helper_.setHopCount(msg.getHopCount());
 
   NodeInfo entering_node = msg.getEnteringNode();
   bool accept = false;
@@ -37,9 +36,9 @@ void MinhtonJoinAlgorithm::processJoin(const MessageJoin &msg) {
     case SearchProgress::kNone:
       // Check if it's not a null node
       if (getRoutingInfo()->areChildrenFull()) {
-        find_end_helper_.forwardToAdjacentNode(entering_node);
+        find_end_helper_.forwardToAdjacentNode(entering_node, msg.getHopCount());
       } else {
-        accept = find_end_helper_.decideNextStep(entering_node);
+        accept = find_end_helper_.decideNextStep(entering_node, msg.getHopCount());
       }
       break;
 
@@ -51,14 +50,14 @@ void MinhtonJoinAlgorithm::processJoin(const MessageJoin &msg) {
       if (!accept) {
         // The SearchProgress is either left (1) or right (0) in this case
         auto search_left = static_cast<bool>(msg.getSearchProgress());
-        find_end_helper_.searchEndOnLevel(entering_node, search_left);
+        find_end_helper_.searchEndOnLevel(entering_node, search_left, msg.getHopCount());
       }
       break;
 
     // Find out whether the current level is completely filled (level h-2 or perfect tree) or not
     // (level h-1)
     case SearchProgress::kCheckRight:
-      find_end_helper_.checkRight(entering_node);
+      find_end_helper_.checkRight(entering_node, msg.getHopCount());
       break;
 
     default:
@@ -70,8 +69,6 @@ void MinhtonJoinAlgorithm::processJoin(const MessageJoin &msg) {
   if (accept) {
     performAcceptChild(entering_node, true);
   }
-
-  find_end_helper_.resetHopCount();
 }
 
 uint32_t MinhtonJoinAlgorithm::performSendUpdateNeighborMessagesAboutEnteringNode(

--- a/minhton/src/algorithms/join/minhton_join_algorithm.cpp
+++ b/minhton/src/algorithms/join/minhton_join_algorithm.cpp
@@ -26,6 +26,7 @@ void MinhtonJoinAlgorithm::processJoin(const MessageJoin &msg) {
     access_->procedure_info->saveEventId(ProcedureKey::kJoinProcedure,
                                          msg.getHeader().getRefEventId());
   }
+  find_end_helper_.setHopCount(msg.getHopCount());
 
   NodeInfo entering_node = msg.getEnteringNode();
   bool accept = false;
@@ -69,6 +70,8 @@ void MinhtonJoinAlgorithm::processJoin(const MessageJoin &msg) {
   if (accept) {
     performAcceptChild(entering_node, true);
   }
+
+  find_end_helper_.resetHopCount();
 }
 
 uint32_t MinhtonJoinAlgorithm::performSendUpdateNeighborMessagesAboutEnteringNode(

--- a/minhton/src/algorithms/leave/leave_algorithm_general.cpp
+++ b/minhton/src/algorithms/leave/leave_algorithm_general.cpp
@@ -615,24 +615,6 @@ void LeaveAlgorithmGeneral::sendReplacementOffer() {
   send(message_replacement_offer);
 }
 
-void LeaveAlgorithmGeneral::forwardFindReplacementMessage(NodeInfo forward_to,
-                                                          NodeInfo node_to_replace,
-                                                          SearchProgress leave_case) {
-  uint64_t ref_event_id = 0;
-  if (access_->procedure_info->hasKey(ProcedureKey::kLeaveProcedure)) {
-    ref_event_id = access_->procedure_info->loadEventId(ProcedureKey::kLeaveProcedure);
-  }
-  MinhtonMessageHeader header(getSelfNodeInfo(), forward_to, ref_event_id);
-
-  MessageFindReplacement message_find_replacement(header, node_to_replace, leave_case);
-  if (ref_event_id == 0) {
-    auto event_id = message_find_replacement.getHeader().getEventId();
-    access_->procedure_info->saveEventId(ProcedureKey::kLeaveProcedure, event_id);
-    LOG_EVENT(EventType::kLeaveEvent, event_id);
-  }
-  send(message_find_replacement);
-}
-
 void LeaveAlgorithmGeneral::replaceMyself(const NodeInfo &node_to_replace,
                                           std::vector<NodeInfo> neighbors_of_node_to_replace) {
   auto ref_event_id = access_->procedure_info->loadEventId(ProcedureKey::kLeaveProcedure);

--- a/minhton/src/algorithms/leave/minhton_leave_algorithm.cpp
+++ b/minhton/src/algorithms/leave/minhton_leave_algorithm.cpp
@@ -58,8 +58,11 @@ void MinhtonLeaveAlgorithm::processFindReplacement(const minhton::MessageFindRep
     event_id = message.getHeader().getEventId();
   }
   this->access_->procedure_info->saveEventId(ProcedureKey::kLeaveProcedure, event_id);
+  find_end_helper_.setHopCount(message.getHopCount());
+
   this->performFindReplacement(message);
   this->access_->procedure_info->removeEventId(ProcedureKey::kLeaveProcedure);
+  find_end_helper_.resetHopCount();
 }
 
 void MinhtonLeaveAlgorithm::performFindReplacement() {

--- a/minhton/src/algorithms/leave/minhton_leave_algorithm.cpp
+++ b/minhton/src/algorithms/leave/minhton_leave_algorithm.cpp
@@ -82,7 +82,7 @@ void MinhtonLeaveAlgorithm::performFindReplacement() {
   if (is_correct_parent) {
     auto last_child = getRoutingInfo()->getInitializedChildren().back();
     // Forward to last child with own SearchProgress just for this case
-    this->forwardFindReplacementMessage(last_child, leaving_node, SearchProgress::kReplacementNode);
+    find_end_helper_.forwardRequest(last_child, leaving_node, SearchProgress::kReplacementNode);
   }
 }
 
@@ -159,7 +159,7 @@ void MinhtonLeaveAlgorithm::performFindReplacement(const minhton::MessageFindRep
   if (is_correct_parent) {
     auto last_child = getRoutingInfo()->getInitializedChildren().back();
     // Forward to last child with own SearchProgress just for this case
-    this->forwardFindReplacementMessage(last_child, leaving_node, SearchProgress::kReplacementNode);
+    find_end_helper_.forwardRequest(last_child, leaving_node, SearchProgress::kReplacementNode);
   }
 }
 

--- a/minhton/src/message/find_replacement.cpp
+++ b/minhton/src/message/find_replacement.cpp
@@ -11,10 +11,11 @@
 namespace minhton {
 MessageFindReplacement::MessageFindReplacement(MinhtonMessageHeader header,
                                                NodeInfo node_to_replace,
-                                               SearchProgress search_progress)
+                                               SearchProgress search_progress, uint16_t hop_count)
     : header_(std::move(header)),
       node_to_replace_(std::move(node_to_replace)),
-      search_progress_(search_progress) {
+      search_progress_(search_progress),
+      hop_count_(hop_count) {
   header_.setMessageType(MessageType::kFindReplacement);
   MessageLoggingAdditionalInfo logging_info{getNodeToReplace().getLogicalNodeInfo().getUuid(), "",
                                             "Prog: " + std::to_string(search_progress)};
@@ -22,14 +23,12 @@ MessageFindReplacement::MessageFindReplacement(MinhtonMessageHeader header,
   validate();
 }
 
-bool MessageFindReplacement::validateImpl() const {
-  return this->getNodeToReplace().isInitialized();
-}
+bool MessageFindReplacement::validateImpl() const { return getNodeToReplace().isInitialized(); }
 
-minhton::NodeInfo MessageFindReplacement::getNodeToReplace() const {
-  return this->node_to_replace_;
-}
+minhton::NodeInfo MessageFindReplacement::getNodeToReplace() const { return node_to_replace_; }
 
-SearchProgress MessageFindReplacement::getSearchProgress() const { return this->search_progress_; }
+SearchProgress MessageFindReplacement::getSearchProgress() const { return search_progress_; }
+
+uint16_t MessageFindReplacement::getHopCount() const { return hop_count_; }
 
 }  // namespace minhton

--- a/minhton/src/message/join.cpp
+++ b/minhton/src/message/join.cpp
@@ -11,10 +11,11 @@
 namespace minhton {
 
 MessageJoin::MessageJoin(MinhtonMessageHeader header, minhton::NodeInfo entering_node,
-                         SearchProgress search_progress)
+                         SearchProgress search_progress, uint16_t hop_count)
     : header_(std::move(header)),
       entering_node_(std::move(entering_node)),
-      search_progress_(search_progress) {
+      search_progress_(search_progress),
+      hop_count_(hop_count) {
   header_.setMessageType(MessageType::kJoin);
   MessageLoggingAdditionalInfo logging_info{getEnteringNode().getLogicalNodeInfo().getUuid(), "",
                                             "Prog: " + std::to_string(search_progress)};
@@ -29,5 +30,7 @@ bool MessageJoin::validateImpl() const {
 minhton::NodeInfo MessageJoin::getEnteringNode() const { return entering_node_; }
 
 SearchProgress MessageJoin::getSearchProgress() const { return search_progress_; }
+
+uint16_t MessageJoin::getHopCount() const { return hop_count_; }
 
 }  // namespace minhton

--- a/minhton/tests/routing_calculations_test.cpp
+++ b/minhton/tests/routing_calculations_test.cpp
@@ -164,19 +164,19 @@ TEST_CASE("RoutingCalculations calcRightRT", "[RoutingCalculations][calcRightRT]
 
 TEST_CASE("RoutingCalculations calcPrioSet", "[RoutingCalculations][calcPrioSet]") {
   // (level, fanout)
-  std::vector<std::tuple<uint16_t, uint8_t>> tests = {
+  std::vector<std::tuple<uint32_t, uint16_t>> tests = {
       std::make_tuple(0, 2),  std::make_tuple(1, 2), std::make_tuple(2, 2), std::make_tuple(4, 2),
       std::make_tuple(10, 2), std::make_tuple(4, 3), std::make_tuple(5, 3), std::make_tuple(2, 3),
       std::make_tuple(6, 5),  std::make_tuple(5, 5), std::make_tuple(4, 6), std::make_tuple(3, 10),
       std::make_tuple(4, 7)};
 
   for (auto const &test : tests) {
-    uint16_t level = std::get<0>(test);
-    uint8_t fanout = std::get<1>(test);
+    uint32_t level = std::get<0>(test);
+    uint16_t fanout = std::get<1>(test);
     uint16_t max_num = pow(fanout, level);
 
     auto prio_set = calcPrioSet(level, fanout);
-    auto covered = std::set<uint16_t>();
+    auto covered = std::set<uint32_t>();
 
     for (auto const &prio_num : prio_set) {
       covered.insert(prio_num);


### PR DESCRIPTION
Fixes #111, #112

# Proposed Changes
- #111 (Use consistent data types for seed, fanout, level, number)
- Use std::find instead of for loops as discussed in #104
- Remove semicolons at the end of SERIALIZE calls for consistency
- Don't process minhton messages that were dropped in prepareReceiving
- Remove abundant minhton method
- #112 (Catch forwarding loops)
- Print SQL query that created a problem (not for deferred logging)

# Definition of Done (optional)
- [X] Feature is implemented
- [X] No known bugs that stops the correct execution
- [X] CI / CD pipeline passed
- [X] The code guidelines were followed
- ~~[ ] Unit and / or Integration tests for the new feature~~
- ~~[ ] New feature was added to the documentation~~
