### PR TITLE
feat(cpps): Save order state in Order object 

### DIFF
--- a/daisi/scenarios/cpps/default.yml
+++ b/daisi/scenarios/cpps/default.yml
@@ -10,9 +10,7 @@ topology:
     depth:   0
 
 initial_number_of_amrs: 12
-number_of_material_flows: 5
 number_of_material_flow_agents: 5
-do_material_flow_agents_leave_after_finish: false
 
 algorithm:
   assignment_strategy: iterated_auction

--- a/daisi/src/cpps/common/CMakeLists.txt
+++ b/daisi/src/cpps/common/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(daisi_cpps_common_cpps_logger_ns3
         daisi_logging_definitions
         daisi_material_flow_model_task
         solanet_uuid
-
+        daisi_cpps_logical_message_material_flow_update
         PRIVATE
         solanet_serializer
         solanet_serialize

--- a/daisi/src/cpps/common/cpps_logger_ns3.h
+++ b/daisi/src/cpps/common/cpps_logger_ns3.h
@@ -21,6 +21,7 @@
 
 #include "SOLA/service.h"
 #include "cpps/amr/message/amr_state.h"
+#include "cpps/logical/message/material_flow_update.h"
 #include "cpps/model/order_states.h"
 #include "logging/definitions.h"
 #include "material_flow/model/task.h"
@@ -92,15 +93,6 @@ struct ExecutedOrderUtilityLoggingInfo {
   double utility;
 };
 
-struct MaterialFlowOrderUpdateLoggingInfo {
-  std::string amr_uuid;
-  AmrState amr_state = AmrState::kIdle;
-  OrderStates order_state = OrderStates::kCreated;
-  material_flow::Task task;
-  uint8_t order_index = 0;
-  util::Position position;
-};
-
 class CppsLoggerNs3 {
 public:
   CppsLoggerNs3() = delete;
@@ -123,7 +115,7 @@ public:
                        uint8_t state);
   void logMaterialFlowOrder(const material_flow::Order &order, const std::string &task_uuid);
   void logMaterialFlowTask(const material_flow::Task &task, const std::string &material_flow_uuid);
-  void logMaterialFlowOrderUpdate(const MaterialFlowOrderUpdateLoggingInfo &logging_info);
+  void logMaterialFlowOrderUpdate(const cpps::logical::MaterialFlowUpdate &logging_info);
 
   // Used for loggers which are initialized before node starts
   // TODO Refactor to other class

--- a/daisi/src/cpps/common/cpps_logger_ns3_material_flow.cpp
+++ b/daisi/src/cpps/common/cpps_logger_ns3_material_flow.cpp
@@ -168,7 +168,7 @@ static const std::string kCreateMaterialFlowOrderHistory =
 static bool material_flow_order_history_exists_ = false;
 
 void CppsLoggerNs3::logMaterialFlowOrderUpdate(
-    const MaterialFlowOrderUpdateLoggingInfo &logging_info) {
+    const cpps::logical::MaterialFlowUpdate &logging_info) {
   if (!material_flow_order_history_exists_) {
     log_(kCreateMaterialFlowOrderHistory);
     material_flow_order_history_exists_ = true;

--- a/daisi/src/cpps/common/cpps_manager.cpp
+++ b/daisi/src/cpps/common/cpps_manager.cpp
@@ -257,22 +257,9 @@ void CppsManager::clearFinishedMaterialFlows() {
                              ->GetObject<MaterialFlowLogicalAgentApplication>()
                              ->application;
 
-    if (mf_app) {
-      if (scenario_.do_material_flow_agents_leave_after_finish && mf_app->canStop()) {
-        found_running_matrial_flow_app = true;
-        material_flows_.Get(i)
-            ->GetApplication(0)
-            ->GetObject<MaterialFlowLogicalAgentApplication>()
-            ->application.reset();
-
-      } else if (mf_app->isFinished()) {
-        number_material_flows_finished_++;
-        found_running_matrial_flow_app = true;
-
-        if (scenario_.do_material_flow_agents_leave_after_finish) {
-          mf_app->prepareStop();
-        }
-      }
+    if (mf_app && mf_app->isFinished()) {
+      number_material_flows_finished_++;
+      found_running_matrial_flow_app = true;
     }
   }
 

--- a/daisi/src/cpps/common/scenariofile/cpps_scenariofile.h
+++ b/daisi/src/cpps/common/scenariofile/cpps_scenariofile.h
@@ -82,9 +82,7 @@ struct AlgorithmScenario {
 struct CppsScenariofile : public GeneralScenariofile {
   explicit CppsScenariofile(const std::string &path_to_file) : GeneralScenariofile(path_to_file) {
     SERIALIZE_VAR(initial_number_of_amrs);
-    SERIALIZE_VAR(number_of_material_flows);
     SERIALIZE_VAR(number_of_material_flow_agents);
-    SERIALIZE_VAR(do_material_flow_agents_leave_after_finish);
 
     SERIALIZE_VAR(algorithm);
     SERIALIZE_VAR(topology);
@@ -99,10 +97,7 @@ struct CppsScenariofile : public GeneralScenariofile {
   }
 
   uint16_t initial_number_of_amrs = 0;
-  uint16_t number_of_material_flows = 0;
   uint16_t number_of_material_flow_agents = 0;
-
-  bool do_material_flow_agents_leave_after_finish = false;
 
   AlgorithmScenario algorithm;
   TopologyScenario topology;

--- a/daisi/src/cpps/logical/algorithms/assignment/CMakeLists.txt
+++ b/daisi/src/cpps/logical/algorithms/assignment/CMakeLists.txt
@@ -37,6 +37,8 @@ target_link_libraries(daisi_cpps_logical_algorithms_assignment_iterated_auction_
     ns3::libcore
     daisi_cpps_amr_model_amr_fleet
     daisi_cpps_common_cpps_communicator
+    daisi_cpps_logical_message_material_flow_update
+    daisi_material_flow_model_material_flow
 )
 
 add_library(daisi_cpps_logical_algorithms_assignment_iterated_auction_assignment_participant STATIC)

--- a/daisi/src/cpps/logical/algorithms/assignment/centralized_initiator.cpp
+++ b/daisi/src/cpps/logical/algorithms/assignment/centralized_initiator.cpp
@@ -82,17 +82,4 @@ void CentralizedInitiator::readAmrRequestFuture() {
   preparation_finished_ = true;
 }
 
-void CentralizedInitiator::logMaterialFlowOrderStatesOfTask(const material_flow::Task &task,
-                                                            const OrderStates &order_state) {
-  // log each order of the task
-  for (auto i = 0; i < task.getOrders().size(); i++) {
-    MaterialFlowOrderUpdateLoggingInfo logging_info;
-    logging_info.task = task;
-    logging_info.order_index = i;
-    logging_info.order_state = order_state;
-
-    logger_->logMaterialFlowOrderUpdate(logging_info);
-  }
-}
-
 }  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/algorithms/assignment/centralized_initiator.h
+++ b/daisi/src/cpps/logical/algorithms/assignment/centralized_initiator.h
@@ -64,12 +64,6 @@ protected:
   /// @param info The necessary information about the new participant.
   virtual void storeParticipant(ParticipantInfo &info) = 0;
 
-  /// @brief Log the new state of a task.
-  /// @param task The changed task.
-  /// @param order_state The new order state.
-  void logMaterialFlowOrderStatesOfTask(const material_flow::Task &task,
-                                        const OrderStates &order_state);
-
   /// @brief All material flows that have been received to assign their tasks.
   std::vector<material_flow::MFDLScheduler> material_flows_;
 

--- a/daisi/src/cpps/logical/algorithms/assignment/iterated_auction_assignment_initiator.h
+++ b/daisi/src/cpps/logical/algorithms/assignment/iterated_auction_assignment_initiator.h
@@ -24,6 +24,7 @@
 #include "auction_initiator_state.h"
 #include "cpps/common/cpps_communicator.h"
 #include "layered_precedence_graph.h"
+#include "material_flow/model/material_flow.h"
 #include "utils/structure_helpers.h"
 
 namespace daisi::cpps::logical {
@@ -130,6 +131,8 @@ private:
     daisi::util::Duration waiting_to_receive_winner_responses = 0.3;
 
   } delays_;
+
+  std::shared_ptr<material_flow::MFDLScheduler> material_flow_;
 };
 
 }  // namespace daisi::cpps::logical

--- a/daisi/src/cpps/logical/algorithms/assignment/layered_precedence_graph.cpp
+++ b/daisi/src/cpps/logical/algorithms/assignment/layered_precedence_graph.cpp
@@ -21,7 +21,7 @@
 namespace daisi::cpps::logical {
 
 LayeredPrecedenceGraph::LayeredPrecedenceGraph(
-    std::shared_ptr<daisi::material_flow::MFDLScheduler> /*scheduler*/,
+    std::shared_ptr<daisi::material_flow::MFDLScheduler> scheduler,
     const std::string &connection_string) {
   // TODO transform scheduler content to vertices and edges
 
@@ -47,6 +47,12 @@ LayeredPrecedenceGraph::LayeredPrecedenceGraph(
         "tos32", {}, material_flow::Location("0x0", "type", util::Position(5, 5)));
     material_flow::TransportOrder to3({pickup3}, delivery3);
     material_flow::Task task3("task3", connection_string, {to3}, {});
+
+    // TODO Workaround to add tasks to materialflow object
+    // while Material flow is hardcoded here.
+    scheduler->addTask(task1);
+    scheduler->addTask(task2);
+    scheduler->addTask(task3);
 
     amr::AmrStaticAbility ability1(amr::LoadCarrier(amr::LoadCarrier::Types::kPackage), 20);
     amr::AmrStaticAbility ability2(amr::LoadCarrier(amr::LoadCarrier::Types::kEuroBox), 20);

--- a/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.h
+++ b/daisi/src/cpps/logical/material_flow/material_flow_logical_agent.h
@@ -49,7 +49,7 @@ public:
   /// @brief Checking whether the agent is currently handling a material flow or running idle
   /// instead.
   /// @return status whether the agent is busy or not
-  bool isBusy();
+  bool isBusy() const;
 
   bool isFinished() const;
 
@@ -68,13 +68,13 @@ protected:
   /// @param m received message
   void topicMessageReceiveFunction(const sola::TopicMessage &m) override;
 
-  /// @brief Material flows that
-  std::vector<std::shared_ptr<daisi::material_flow::MFDLScheduler>> material_flows_;
-
   /// @brief make the mf agent discoverable for findService queries
   void setServices();
 
 private:
+  /// @brief Current material flow
+  std::shared_ptr<daisi::material_flow::MFDLScheduler> material_flow_;
+
   /// Simple flag to represent that the agent is still in the initialization process.
   bool waiting_for_start_ = false;
 

--- a/daisi/src/material_flow/model/CMakeLists.txt
+++ b/daisi/src/material_flow/model/CMakeLists.txt
@@ -91,6 +91,7 @@ target_sources(daisi_material_flow_model_transport_order
 target_link_libraries(daisi_material_flow_model_transport_order
     PUBLIC
     daisi_material_flow_model_transport_order_step
+    daisi_cpps_model_order_states
     PRIVATE
     solanet_serialize
     solanet_uuid
@@ -111,6 +112,7 @@ target_link_libraries(daisi_material_flow_model_task
     daisi_cpps_amr_model_amr_static_ability
     daisi_material_flow_model_time_window
     solanet_serialize
+    daisi_cpps_model_order_states
 
     PRIVATE
     solanet_uuid
@@ -126,7 +128,8 @@ target_sources(daisi_material_flow_model_material_flow
 target_link_libraries(daisi_material_flow_model_material_flow
     PUBLIC
     daisi_material_flow_model_task
-
+    daisi_cpps_model_order_states
+    daisi_cpps_logical_message_material_flow_update
     PRIVATE
     solanet_serialize
 )

--- a/daisi/src/material_flow/model/material_flow.h
+++ b/daisi/src/material_flow/model/material_flow.h
@@ -17,9 +17,12 @@
 #ifndef DAISI_MATERIAL_FLOW_MATERIAL_FLOW_H_
 #define DAISI_MATERIAL_FLOW_MATERIAL_FLOW_H_
 
+#include <functional>
 #include <variant>
 #include <vector>
 
+#include "cpps/logical/message/material_flow_update.h"
+#include "cpps/model/order_states.h"
 #include "solanet/serializer/serialize.h"
 #include "task.h"
 
@@ -30,12 +33,23 @@ class MFDLScheduler {
 public:
   MFDLScheduler() = default;
 
-  explicit MFDLScheduler(const std::string & /*mfdl_program*/) {}
+  MFDLScheduler(
+      const std::string & /*mfdl_program*/,
+      std::function<void(const daisi::cpps::logical::MaterialFlowUpdate &)> log_update_fct)
+      : log_order_state_update_fct_(std::move(log_update_fct)) {}
+
+  void processOrderUpdate(const daisi::cpps::logical::MaterialFlowUpdate &update);
+
+  bool isFinished() const;
 
   SERIALIZE(tasks_)
 
+  void addTask(Task task);
+
 private:
   std::vector<Task> tasks_;
+
+  std::function<void(const daisi::cpps::logical::MaterialFlowUpdate &)> log_order_state_update_fct_;
 };
 
 }  // namespace daisi::material_flow

--- a/daisi/src/material_flow/model/task.cpp
+++ b/daisi/src/material_flow/model/task.cpp
@@ -71,4 +71,21 @@ void Task::setSpawnTime(const util::Duration &spawn_time) {
   throw std::runtime_error("TimeWindow not set");
 }
 
+void Task::setOrderState(uint8_t order_index, daisi::cpps::OrderStates state) {
+  auto &order = orders_.at(order_index);
+  std::visit([this, state](auto &ord) { this->setOrderState(ord, state); }, order);
+}
+
+void Task::setOrderState(TransportOrder &order, daisi::cpps::OrderStates state) {
+  order.setOrderState(state);
+}
+
+void Task::setOrderState(MoveOrder & /*order*/, daisi::cpps::OrderStates /*state*/) {
+  throw std::runtime_error("not supported yet");
+}
+
+void Task::setOrderState(ActionOrder & /*order*/, daisi::cpps::OrderStates /*state*/) {
+  throw std::runtime_error("not supported yet");
+}
+
 }  // namespace daisi::material_flow

--- a/daisi/src/material_flow/model/task.h
+++ b/daisi/src/material_flow/model/task.h
@@ -21,6 +21,7 @@
 
 #include "action_order.h"
 #include "cpps/amr/model/amr_static_ability.h"
+#include "cpps/model/order_states.h"
 #include "move_order.h"
 #include "solanet/serializer/serialize.h"
 #include "time_window.h"
@@ -55,6 +56,8 @@ public:
   const TimeWindow &getTimeWindow() const;
   void setSpawnTime(const util::Duration &spawn_time);
 
+  void setOrderState(uint8_t order_index, daisi::cpps::OrderStates state);
+
   bool operator<(const Task &other) const { return uuid_ < other.uuid_; }
   bool operator==(const Task &other) const { return uuid_ == other.uuid_; }
   bool operator!=(const Task &other) const { return uuid_ != other.uuid_; }
@@ -63,6 +66,10 @@ public:
             ability_requirement_)
 
 private:
+  void setOrderState(TransportOrder &order, daisi::cpps::OrderStates state);
+  void setOrderState(MoveOrder &order, daisi::cpps::OrderStates state);
+  void setOrderState(ActionOrder &order, daisi::cpps::OrderStates state);
+
   std::string uuid_;
   std::string name_;
   std::string connection_string_;

--- a/daisi/src/material_flow/model/transport_order.h
+++ b/daisi/src/material_flow/model/transport_order.h
@@ -19,6 +19,7 @@
 
 #include <vector>
 
+#include "cpps/model/order_states.h"
 #include "solanet/serializer/serialize.h"
 #include "transport_order_step.h"
 
@@ -41,9 +42,14 @@ public:
 
   bool operator==(const TransportOrder &other) const;
 
+  void setOrderState(cpps::OrderStates state) { state_ = state; }
+  cpps::OrderStates getOrderState() const { return state_; }
+
   SERIALIZE(uuid_, pickup_transport_order_steps_, delivery_transport_order_step_)
 
 private:
+  cpps::OrderStates state_ = cpps::OrderStates::kInvalid;
+
   std::string uuid_;
 
   std::vector<TransportOrderStep> pickup_transport_order_steps_;

--- a/daisi/utils/ci_scenario_files/cpps_test.yml
+++ b/daisi/utils/ci_scenario_files/cpps_test.yml
@@ -10,9 +10,7 @@ topology:
     depth:   0
 
 initial_number_of_amrs: 12
-number_of_material_flows: 5
 number_of_material_flow_agents: 5
-do_material_flow_agents_leave_after_finish: false
 
 algorithm:
   assignment_strategy: iterated_auction

--- a/daisi/utils/ci_scenario_files/round_robin_test.yml
+++ b/daisi/utils/ci_scenario_files/round_robin_test.yml
@@ -10,9 +10,7 @@ topology:
     depth:   0
 
 initial_number_of_amrs: 12
-number_of_material_flows: 1
 number_of_material_flow_agents: 1
-do_material_flow_agents_leave_after_finish: false
 
 algorithm:
   assignment_strategy: round_robin

--- a/docs/daisi/optimaflow-ns3/scenariofile.md
+++ b/docs/daisi/optimaflow-ns3/scenariofile.md
@@ -107,16 +107,6 @@ Currently the number of AMRs cannot be changed at runtime, hence this is the tot
     - Reasonable default: `12`
     - Data type: ``uint64_t``
 
-#### ``number_of_material_flows``
-
-Currently unused.
-
-??? properties
-
-    - Required: :fontawesome-solid-star-of-life:
-    - Reasonable default: `5`
-    - Data type: ``uint64_t``
-
 #### ``number_of_material_flow_agents``
 
 Number of Material flow agents that should be spawned.
@@ -127,17 +117,6 @@ For each agent a separate ns-3 node is created.
     - Required: :fontawesome-solid-star-of-life:
     - Reasonable default: `5`
     - Data type: ``uint64_t``
-
-#### ``do_material_flow_agents_leave_after_finish``
-
-Specifies whether a Material Flow agent should shutdown (disconnect from all network functionalities) after the material flow was finished.
-If set to ``false``, the Material Flow agent stays connected and can be reused for another material flow.
-
-??? properties
-
-    - Required: :fontawesome-solid-star-of-life:
-    - Reasonable default: `false`
-    - Data type: ``bool``
 
 #### ``algorithm``
 


### PR DESCRIPTION
This allows
- centralizing the logging functionaliy in to ``MFDLScheduler``.
- Allows workaround to terminate simulation automatically once all MFs are finished.

# Definition of Done (optional)
- [x] Feature is implemented
- [x] No known bugs that stops the correct execution
- [x] CI / CD pipeline passed
- [x] The code guidelines were followed
- ~[ ] Unit and / or Integration tests for the new feature~
- [x] New feature was added to the documentation
